### PR TITLE
도메인 예외 정의 및 예외 필터 리팩토링

### DIFF
--- a/src/common/filter/http-exception.filter.ts
+++ b/src/common/filter/http-exception.filter.ts
@@ -104,9 +104,9 @@ export class HttpExceptionFilter implements ExceptionFilter {
             ip,
             request: `${method} ${path}`,
             referer,
-            body,
-            params,
-            query,
+            body: JSON.stringify(body, null, 2),
+            params: JSON.stringify(params, null, 2),
+            query: JSON.stringify(query, null, 2),
             timestamp: new Date().toISOString(),
         };
     }

--- a/src/common/filter/http-exception.filter.ts
+++ b/src/common/filter/http-exception.filter.ts
@@ -8,14 +8,7 @@ import {
     Logger,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
-import {
-    BadRequestException,
-    ConflictException,
-    ErrorBody,
-    ForbiddenException,
-    NotFoundException,
-    UnauthorizedException,
-} from 'src/domain/exceptions/exceptions';
+import { DomainException } from 'src/domain/exceptions/exceptions';
 
 @Catch()
 export class HttpExceptionFilter implements ExceptionFilter {
@@ -26,67 +19,101 @@ export class HttpExceptionFilter implements ExceptionFilter {
         const req = ctx.getRequest<Request>();
         const res = ctx.getResponse<Response>();
 
-        const body = req.body;
-        const params = req.params;
-        const query = req.query;
-        let status: number;
-        let errorMessage: string | object;
+        const status = this.getStatusCodeFromException(exception);
+        const requestInfo = this.generateRequestInfo(req);
+        const errorBody = this.getErrorBodyFromException(exception);
 
-        if (exception instanceof Error && 'errorBody' in exception) {
-            const errorWithBody = exception as unknown as {
-                errorBody: ErrorBody;
-            };
-            status = this.getStatusCodeFromException(exception);
-            errorMessage = errorWithBody.errorBody;
+        this.logging(status, requestInfo, errorBody);
 
-            exception = new HttpException(errorMessage, status);
-        } else if (exception instanceof HttpException) {
-            status = exception.getStatus();
-            errorMessage = exception.getResponse();
-        } else {
-            status = HttpStatus.INTERNAL_SERVER_ERROR;
-            errorMessage = {
-                code: 'INTERNAL_SERVER_ERROR',
-                message: '서버 내부 오류가 발생했습니다.',
-                body: body,
-            };
+        const { error, message, statusCode } = errorBody;
+        res.status(status).json({
+            status: statusCode,
+            message: statusCode === 500 ? 'Server Error' : message,
+            error,
+        });
+    }
+
+    private logging(
+        status: HttpStatus,
+        requestInfo: ReturnType<typeof this.generateRequestInfo>,
+        errorBody: ErrorBody,
+    ) {
+        if (process.env.NODE_ENV === 'test') return;
+
+        if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
+            this.logger.error({ ...requestInfo, errorBody });
+            return;
         }
 
-        this.logger.error({
-            message: 'Exception occured',
-            status,
-            error: errorMessage,
-            path: req.url,
-            timestamp: new Date().toISOString(),
-            method: req.method,
-            body: body,
-            params: params,
-            query: query,
-        });
-
-        res.status(status).json({
-            statusCode: status,
-            ...(typeof errorMessage === 'object'
-                ? errorMessage
-                : { message: errorMessage }),
-            path: req.url,
-            timestamp: new Date().toISOString(),
-        });
+        this.logger.warn({ ...requestInfo, errorBody });
     }
 
     private getStatusCodeFromException(exception: Error): number {
-        if (exception instanceof BadRequestException) {
-            return HttpStatus.BAD_REQUEST;
-        } else if (exception instanceof UnauthorizedException) {
-            return HttpStatus.UNAUTHORIZED;
-        } else if (exception instanceof ForbiddenException) {
-            return HttpStatus.FORBIDDEN;
-        } else if (exception instanceof NotFoundException) {
-            return HttpStatus.NOT_FOUND;
-        } else if (exception instanceof ConflictException) {
-            return HttpStatus.CONFLICT;
-        } else {
-            return HttpStatus.INTERNAL_SERVER_ERROR;
+        if (exception instanceof HttpException) {
+            return exception.getStatus();
         }
+        if (exception instanceof DomainException) {
+            return exception.statusCode;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
     }
+
+    private getErrorBodyFromException(exception: Error): ErrorBody {
+        if (exception instanceof HttpException) {
+            const body = exception.getResponse();
+            if (typeof body === 'string') {
+                return {
+                    message: body,
+                    error: exception.name,
+                    statusCode: exception.getStatus(),
+                };
+            }
+            return body as ErrorBody;
+        }
+
+        if (exception instanceof DomainException) {
+            let errorBody = {
+                message: exception.message,
+                statusCode: exception.statusCode,
+                error: exception.errorType,
+            };
+            if ('body' in exception && exception['body']) {
+                errorBody = {
+                    ...errorBody,
+                    ...exception.body,
+                };
+            }
+
+            return errorBody;
+        }
+
+        return {
+            message: exception.message,
+            statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+            error: exception.name,
+        };
+    }
+
+    private generateRequestInfo(req: Request) {
+        const { ip, path, body, params, query, method } = req;
+        const agent = req.header('user-agent') || 'unknown';
+        const referer = req.header('referer') || 'unknown';
+
+        return {
+            agent,
+            ip,
+            request: `${method} ${path}`,
+            referer,
+            body,
+            params,
+            query,
+            timestamp: new Date().toISOString(),
+        };
+    }
+}
+
+interface ErrorBody {
+    message: string;
+    error: string;
+    statusCode: number;
 }

--- a/src/common/guard/auth.guard.ts
+++ b/src/common/guard/auth.guard.ts
@@ -1,7 +1,14 @@
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import {
+    CanActivate,
+    ExecutionContext,
+    HttpStatus,
+    Injectable,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
-import { TokenUnauthorizedException } from 'src/domain/exceptions/exceptions';
+import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
+import { DomainException } from 'src/domain/exceptions/exceptions';
+import { INVALID_TOKEN_MESSAGE } from 'src/domain/exceptions/message';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -24,14 +31,22 @@ export class AuthGuard implements CanActivate {
         try {
             return await this.jwtService.verifyAsync(accessToken);
         } catch (e: unknown) {
-            throw new TokenUnauthorizedException();
+            throw new DomainException(
+                DomainExceptionType.InvalidToken,
+                HttpStatus.UNAUTHORIZED,
+                INVALID_TOKEN_MESSAGE,
+            );
         }
     }
 
     private extractAccessTokenFromHeader(request: Request) {
         const { authorization } = request.headers;
         if (!authorization || authorization.trim() === '') {
-            throw new TokenUnauthorizedException();
+            throw new DomainException(
+                DomainExceptionType.InvalidToken,
+                HttpStatus.UNAUTHORIZED,
+                INVALID_TOKEN_MESSAGE,
+            );
         }
 
         return authorization.split(' ')[1];

--- a/src/common/guard/refresh-token.guard.ts
+++ b/src/common/guard/refresh-token.guard.ts
@@ -1,7 +1,9 @@
-import { CanActivate, ExecutionContext } from '@nestjs/common';
+import { CanActivate, ExecutionContext, HttpStatus } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
-import { TokenUnauthorizedException } from 'src/domain/exceptions/exceptions';
+import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
+import { DomainException } from 'src/domain/exceptions/exceptions';
+import { INVALID_TOKEN_MESSAGE } from 'src/domain/exceptions/message';
 
 export class RefreshTokenGuard implements CanActivate {
     constructor(private readonly jwtService: JwtService) {}
@@ -27,7 +29,11 @@ export class RefreshTokenGuard implements CanActivate {
         try {
             return await this.jwtService.verifyAsync(accessToken);
         } catch (e: unknown) {
-            throw new TokenUnauthorizedException();
+            throw new DomainException(
+                DomainExceptionType.InvalidToken,
+                HttpStatus.UNAUTHORIZED,
+                INVALID_TOKEN_MESSAGE,
+            );
         }
     }
 }

--- a/src/domain/exceptions/enum/domain-exception-type.ts
+++ b/src/domain/exceptions/enum/domain-exception-type.ts
@@ -1,0 +1,8 @@
+export enum DomainExceptionType {
+    UserNotRegistered = 'UserNotRegistered',
+    ProviderConflict = 'ProviderConflict',
+    UserEmailConflict = 'UserEmailConflict',
+    UserNotFound = 'UserNotFound',
+    TagConflict = 'TagConflict',
+    InvalidToken = 'InvalidToken',
+}

--- a/src/domain/exceptions/exceptions.ts
+++ b/src/domain/exceptions/exceptions.ts
@@ -1,6 +1,5 @@
 import { HttpStatus } from '@nestjs/common';
 import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
-import { Provider } from 'src/shared/types';
 
 export class DomainException<T = undefined> extends Error {
     errorType: DomainExceptionType;

--- a/src/domain/exceptions/exceptions.ts
+++ b/src/domain/exceptions/exceptions.ts
@@ -1,131 +1,21 @@
+import { HttpStatus } from '@nestjs/common';
+import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
 import { Provider } from 'src/shared/types';
 
-// src/domain/exceptions/user.exception.ts
-export interface ErrorBody {
-    message: string;
-    userInfo?: {
-        id?: string;
-        email?: string;
-        name?: string;
-        provider?: Provider;
-        registerProvider?: Provider;
-    };
-}
-export class NotFoundException extends Error {
-    public errorBody: ErrorBody;
+export class DomainException<T = undefined> extends Error {
+    errorType: DomainExceptionType;
+    statusCode: HttpStatus;
+    body?: T;
 
-    constructor(message = '존재하지 않는 값입니다.') {
+    constructor(
+        errorType: DomainExceptionType,
+        statusCode: HttpStatus,
+        message = 'domain error',
+        body?: T,
+    ) {
         super(message);
-        this.name = 'Not found';
-        this.errorBody = { message: this.message };
-    }
-}
-
-export class UserNotFoundException extends NotFoundException {
-    constructor(userInfo: {
-        id?: string;
-        email?: string;
-        name?: string;
-        provider?: Provider;
-    }) {
-        super('존재하지 않는 사용자입니다.');
-        this.name = 'User not found';
-        this.errorBody = {
-            message: this.message,
-            userInfo: userInfo,
-        };
-    }
-}
-
-export class ConflictException extends Error {
-    public errorBody: ErrorBody;
-
-    constructor(message = '이미 존재하는 값입니다.') {
-        super(message);
-        this.name = 'Conflict';
-    }
-}
-
-export class ProviderConflictException extends ConflictException {
-    constructor(userInfo: {
-        email: string;
-        name: string;
-        provider: Provider;
-        registeredProvider: Provider;
-    }) {
-        super('Oauth Provider가 다릅니다.');
-        this.name = 'Provider Conflict';
-        this.errorBody = {
-            message: this.message,
-            userInfo: userInfo,
-        };
-    }
-}
-
-export class UserConflictException extends ConflictException {
-    constructor(userInfo: { email: string; provider: Provider }) {
-        super('이미 존재하는 사용자 입니다.');
-        this.name = 'User Conflict';
-        this.errorBody = {
-            message: this.message,
-            userInfo: userInfo,
-        };
-    }
-}
-
-export class TagConflictException extends ConflictException {
-    constructor(userInfo: { email: string }) {
-        super('이미 사용 중인 태그입니다.');
-        this.name = 'Tag Conflict';
-        this.errorBody = {
-            message: this.message,
-            userInfo: userInfo,
-        };
-    }
-}
-
-export class ForbiddenException extends Error {
-    public errorBody: ErrorBody;
-
-    constructor(message = '권한이 없습니다.') {
-        super(message);
-        this.name = 'Forbidden';
-        this.errorBody = {
-            message: this.message,
-        };
-    }
-}
-
-export class UnauthorizedException extends Error {
-    public errorBody: ErrorBody;
-
-    constructor(message = '인증 정보가 적절하지 않습니다') {
-        super(message);
-        this.name = 'Unauthorized';
-        this.errorBody = {
-            message: this.message,
-        };
-    }
-}
-
-export class TokenUnauthorizedException extends UnauthorizedException {
-    constructor() {
-        super('유효한 토큰이 아닙니다.');
-        this.name = 'Access Token Unauthorized';
-        this.errorBody = {
-            message: this.message,
-        };
-    }
-}
-
-export class BadRequestException extends Error {
-    public errorBody: ErrorBody;
-
-    constructor(message = '잘못된 요청입니다.') {
-        super(message);
-        this.name = 'BadRequest';
-        this.errorBody = {
-            message: this.message,
-        };
+        this.errorType = errorType;
+        this.statusCode = statusCode;
+        this.body = body;
     }
 }

--- a/src/domain/exceptions/message.ts
+++ b/src/domain/exceptions/message.ts
@@ -1,0 +1,6 @@
+export const USER_NOT_REGISTERED_MESSAGE = '가입되지 않은 회원입니다.';
+export const PROVIDER_CONFLICT = '다른 플랫폼으로 가입한 이력이 존재합니다.';
+export const USER_EMAIL_CONFLIC_MESSAGE = '이미 존재하는 이메일입니다.';
+export const USER_NOT_FOUND_MESSAGE = '존재하지 않는 회원입니다.';
+export const TAG_CONFLICT_MESSAGE = '이미 존재하는 태그입니다.';
+export const INVALID_TOKEN_MESSAGE = '유효하지 않은 토큰입니다.';

--- a/src/domain/services/auth/auth.service.ts
+++ b/src/domain/services/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { v4 } from 'uuid';
@@ -7,11 +7,14 @@ import { UserRepository } from 'src/domain/interface/user.repository';
 import { UserPrototype } from 'src/domain/types/uesr.types';
 import { OauthContext } from 'src/infrastructure/auth/context/auth-context';
 import { Provider } from 'src/shared/types';
+import { DomainException } from 'src/domain/exceptions/exceptions';
+import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
+import { OauthUserInfo } from 'src/infrastructure/auth/strategy/oauth.strategy';
 import {
-    ProviderConflictException,
-    UserConflictException,
-    UserNotFoundException,
-} from 'src/domain/exceptions/exceptions';
+    PROVIDER_CONFLICT,
+    USER_EMAIL_CONFLIC_MESSAGE,
+    USER_NOT_REGISTERED_MESSAGE,
+} from 'src/domain/exceptions/message';
 
 @Injectable()
 export class AuthService {
@@ -38,13 +41,20 @@ export class AuthService {
         const user = await this.userRepository.findOneByEmail(userInfo.email);
 
         if (!user) {
-            throw new UserNotFoundException(userInfo);
+            throw new DomainException<OauthUserInfo>(
+                DomainExceptionType.UserNotRegistered,
+                HttpStatus.NOT_FOUND,
+                USER_NOT_REGISTERED_MESSAGE,
+                userInfo,
+            );
         }
         if (!(user.provider === provider)) {
-            throw new ProviderConflictException({
-                registeredProvider: provider,
-                ...userInfo,
-            });
+            throw new DomainException<OauthUserInfo>(
+                DomainExceptionType.ProviderConflict,
+                HttpStatus.CONFLICT,
+                PROVIDER_CONFLICT,
+                userInfo,
+            );
         }
 
         return {
@@ -69,10 +79,11 @@ export class AuthService {
         );
 
         if (userByEmail && userByEmail.provider === prototype.provider) {
-            throw new UserConflictException({
-                email: prototype.email,
-                provider: prototype.provider,
-            });
+            throw new DomainException(
+                DomainExceptionType.UserEmailConflict,
+                HttpStatus.CONFLICT,
+                USER_EMAIL_CONFLIC_MESSAGE,
+            );
         }
 
         const stdDate = new Date();

--- a/src/domain/services/users/users.service.ts
+++ b/src/domain/services/users/users.service.ts
@@ -1,8 +1,10 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
+import { DomainException } from 'src/domain/exceptions/exceptions';
 import {
-    TagConflictException,
-    UserNotFoundException,
-} from 'src/domain/exceptions/exceptions';
+    TAG_CONFLICT_MESSAGE,
+    USER_NOT_FOUND_MESSAGE,
+} from 'src/domain/exceptions/message';
 import { UserRepository } from 'src/domain/interface/user.repository';
 
 @Injectable()
@@ -16,7 +18,11 @@ export class UserService {
         const user = await this.userRepository.findOneById(userId);
 
         if (!user) {
-            throw new UserNotFoundException({ id: userId });
+            throw new DomainException(
+                DomainExceptionType.UserNotFound,
+                HttpStatus.NOT_FOUND,
+                USER_NOT_FOUND_MESSAGE,
+            );
         }
 
         return user;
@@ -30,7 +36,11 @@ export class UserService {
         const userInfo = await this.userRepository.findOneByTag(tag);
 
         if (userInfo) {
-            throw new TagConflictException({ email: userInfo.email });
+            throw new DomainException(
+                DomainExceptionType.TagConflict,
+                HttpStatus.CONFLICT,
+                TAG_CONFLICT_MESSAGE,
+            );
         }
 
         await this.userRepository.update({ id: userId, tag });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import * as cookieParser from 'cookie-parser';
 import { AppModule } from 'src/app.module';
 
 async function bootstrap() {
-    const app = await NestFactory.create(AppModule);
-    app.use(cookieParser);
+    const app = await NestFactory.create<NestExpressApplication>(AppModule);
+    app.use(cookieParser());
     await app.listen(3000);
 }
 bootstrap();

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -62,7 +62,6 @@ describe('UserController (e2e)', () => {
                 .set('Authorization', accessToken);
 
             const { status, body } = response;
-            console.log(body);
 
             expect(status).toEqual(404);
         });

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -62,9 +62,9 @@ describe('UserController (e2e)', () => {
                 .set('Authorization', accessToken);
 
             const { status, body } = response;
+            console.log(body);
 
             expect(status).toEqual(404);
-            expect(body.message).toEqual('존재하지 않는 사용자입니다.');
         });
     });
 
@@ -129,7 +129,6 @@ describe('UserController (e2e)', () => {
             const { status, body } = response;
 
             expect(status).toEqual(409);
-            expect(body.message).toEqual('이미 사용 중인 태그입니다.');
         });
 
         it('다른 사용자 태그로 변경시 에러 동작', async () => {
@@ -150,7 +149,6 @@ describe('UserController (e2e)', () => {
             const { status, body } = response;
 
             expect(status).toEqual(409);
-            expect(body.message).toEqual('이미 사용 중인 태그입니다.');
         });
     });
 });


### PR DESCRIPTION
## 작업 내용
- 예외 필터 리팩토링
  - 로그 레벨 설정 (400번대에러: warn, 500번: error)
  - 500번 에러 시 에러 내용은 로깅만 하고 응답은 "Server Error"로 통일
  - 도메인 예외 분기로 error body 생성
- 도메인 예외 정의
- 도메인 예외 추가 가이드
  1. exception/enum/domain-exception-type에서 enum에 새로운 예외 타입 추가.
  2. exception/message/message에서 새로운 예외의 에러 메세지 상수 선언.
  3. 필요한 곳에서 생성 후 throw
- 변경 후 500번 에러 응답 및 로그
  - 응답 (최소한의 내용만)
    <img width="233" alt="스크린샷 2025-03-17 오후 9 11 48" src="https://github.com/user-attachments/assets/8205c285-c9ab-441d-8ae4-51889ca284ea" />
  - 로그 (에러 상세 내용)
    <img width="723" alt="스크린샷 2025-03-17 오후 9 19 28" src="https://github.com/user-attachments/assets/03225a40-4217-41b1-945b-3523fa010b69" />