### PR TITLE
친구 요청 조회 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "test:cov": "jest --coverage",
         "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
         "test": "dotenv -e .env.test -- jest --config ./test/unit/jest.json --verbose --runInBand --watch",
-        "test:e2e": "dotenv -e .env.test -- jest --config ./test/e2e/jest-e2e.json --verbose",
+        "test:e2e": "dotenv -e .env.test -- jest --config ./test/e2e/jest-e2e.json --runInBand --verbose",
         "docker:up": "docker compose up -d && sleep 5 && dotenv -e .env.test -- npx prisma migrate dev",
         "docker:down": "docker compose down"
     },

--- a/prisma/migrations/20250414112053_add_relation_friend_request_and_user/migration.sql
+++ b/prisma/migrations/20250414112053_add_relation_friend_request_and_user/migration.sql
@@ -1,0 +1,5 @@
+-- AddForeignKey
+ALTER TABLE "friend_request" ADD CONSTRAINT "friend_request_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "friend_request" ADD CONSTRAINT "friend_request_receiverId_fkey" FOREIGN KEY ("receiverId") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,8 @@ model User {
 
   IslandJoins  IslandJoin[]
   ChatMessages ChatMessage[]
+  FriendRequestsSent     FriendRequest[] @relation("Sender")
+  FriendRequestsReceived FriendRequest[] @relation("Receiver")
 
   @@unique([tag, deletedAt])
   @@unique([email, deletedAt])
@@ -54,6 +56,9 @@ model FriendRequest {
   createdAt  DateTime            @map("created_at")
   updatedAt  DateTime            @map("updated_at")
   deletedAt  DateTime?           @map("deleted_at")
+
+  sender  User @relation("Sender", fields: [senderId], references: [id])
+  receiver User @relation("Receiver", fields: [receiverId], references: [id])
 
   @@index([senderId])
   @@index([receiverId])

--- a/src/domain/components/friends/friend-reader.ts
+++ b/src/domain/components/friends/friend-reader.ts
@@ -3,6 +3,7 @@ import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception
 import { DomainException } from 'src/domain/exceptions/exceptions';
 import { FRIEND_REQUEST_NOT_FOUND_MESSAGE } from 'src/domain/exceptions/message';
 import { FriendRepository } from 'src/domain/interface/friend.repository';
+import { FriendRequestDirection } from 'src/domain/types/friend.types';
 
 @Injectable()
 export class FriendReader {
@@ -27,5 +28,26 @@ export class FriendReader {
         }
 
         return friendRequest;
+    }
+
+    async readFriendsRequests(
+        userId: string,
+        direction: FriendRequestDirection,
+        limit: number,
+        cursor?: string,
+    ) {
+        if (direction === 'received') {
+            return await this.friendRepository.findReceivedRequestsByUserId(
+                userId,
+                limit,
+                cursor,
+            );
+        }
+
+        return await this.friendRepository.findSentRequestsByUserId(
+            userId,
+            limit,
+            cursor,
+        );
     }
 }

--- a/src/domain/components/users/user-reader.ts
+++ b/src/domain/components/users/user-reader.ts
@@ -6,7 +6,7 @@ import {
     USER_NOT_FOUND_MESSAGE,
 } from 'src/domain/exceptions/message';
 import { UserRepository } from 'src/domain/interface/user.repository';
-import { PaginatedUsers } from 'src/domain/types/uesr.types';
+import { PaginatedUsers, UserInfo } from 'src/domain/types/uesr.types';
 import { Varient } from 'src/presentation/dto/users/request/search-users.request';
 
 @Injectable()
@@ -16,7 +16,7 @@ export class UserReader {
         private readonly userRepository: UserRepository,
     ) {}
 
-    async readProfile(userId: string) {
+    async readProfile(userId: string): Promise<UserInfo> {
         const user = await this.userRepository.findOneById(userId);
 
         if (!user) {

--- a/src/domain/interface/friend.repository.ts
+++ b/src/domain/interface/friend.repository.ts
@@ -1,5 +1,9 @@
 import { FriendEntity } from '../entities/friend/friend.entity';
-import { FriendData } from '../types/friend.types';
+import {
+    FriendData,
+    ReceivedPaginatedFriendRequests,
+    SentPaginatedFriendRequests,
+} from '../types/friend.types';
 
 export interface FriendRepository {
     save(data: FriendEntity): Promise<void>;
@@ -7,6 +11,16 @@ export interface FriendRepository {
         senderId: string,
         receiverId: string,
     ): Promise<FriendData | null>;
+    findReceivedRequestsByUserId(
+        userId: string,
+        limit: number,
+        cursor?: string,
+    ): Promise<ReceivedPaginatedFriendRequests>;
+    findSentRequestsByUserId(
+        userId: string,
+        limit: number,
+        cursor?: string,
+    ): Promise<SentPaginatedFriendRequests>;
 }
 
 export const FriendRepository = Symbol('FriendRepository');

--- a/src/domain/interface/friend.repository.ts
+++ b/src/domain/interface/friend.repository.ts
@@ -1,9 +1,5 @@
 import { FriendEntity } from '../entities/friend/friend.entity';
-import {
-    FriendData,
-    ReceivedPaginatedFriendRequests,
-    SentPaginatedFriendRequests,
-} from '../types/friend.types';
+import { FriendData, PaginatedFriendRequests } from '../types/friend.types';
 
 export interface FriendRepository {
     save(data: FriendEntity): Promise<void>;
@@ -15,12 +11,12 @@ export interface FriendRepository {
         userId: string,
         limit: number,
         cursor?: string,
-    ): Promise<ReceivedPaginatedFriendRequests>;
+    ): Promise<PaginatedFriendRequests>;
     findSentRequestsByUserId(
         userId: string,
         limit: number,
         cursor?: string,
-    ): Promise<SentPaginatedFriendRequests>;
+    ): Promise<PaginatedFriendRequests>;
 }
 
 export const FriendRepository = Symbol('FriendRepository');

--- a/src/domain/services/friends/friends.service.ts
+++ b/src/domain/services/friends/friends.service.ts
@@ -5,16 +5,11 @@ import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
 import {
     FriendPrototype,
     FriendRequestDirection,
-    ReceivedFriendRequestsData,
-    SentFriendRequestsData,
 } from 'src/domain/types/friend.types';
 import { v4 } from 'uuid';
 import { FriendReader } from 'src/domain/components/friends/friend-reader';
 import { UserReader } from 'src/domain/components/users/user-reader';
-import {
-    FriendRequestItemDto,
-    GetFriendRequestsResponseDto,
-} from 'src/presentation/dto/friends/response/get-friend-request-list.response';
+import { GetFriendRequestsResponseDto } from 'src/presentation/dto/friends/response/get-friend-request-list.response';
 
 @Injectable()
 export class FriendsService {
@@ -58,29 +53,6 @@ export class FriendsService {
             return { data: [], nextCursor: null };
         }
 
-        const responseData: FriendRequestItemDto[] = [];
-
-        for (const req of requestList) {
-            const friendUserId =
-                direction === 'received'
-                    ? (req as ReceivedFriendRequestsData).senderId
-                    : (req as SentFriendRequestsData).receiverId;
-
-            const userProfile = await this.userReader.readProfile(friendUserId);
-
-            if (userProfile) {
-                responseData.push({
-                    id: req.id,
-                    user: {
-                        id: userProfile.id,
-                        nickname: userProfile.nickname,
-                        tag: userProfile.tag,
-                        avatarKey: userProfile.avatarKey,
-                    },
-                });
-            }
-        }
-
-        return { data: responseData, nextCursor };
+        return { data: requestList, nextCursor };
     }
 }

--- a/src/domain/services/friends/friends.service.ts
+++ b/src/domain/services/friends/friends.service.ts
@@ -2,14 +2,27 @@ import { Injectable } from '@nestjs/common';
 import { FriendWriter } from 'src/domain/components/friends/friend-writer';
 import { FriendChecker } from 'src/domain/components/friends/friend-checker';
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
-import { FriendPrototype } from 'src/domain/types/friend.types';
+import {
+    FriendPrototype,
+    FriendRequestDirection,
+    ReceivedFriendRequestsData,
+    SentFriendRequestsData,
+} from 'src/domain/types/friend.types';
 import { v4 } from 'uuid';
+import { FriendReader } from 'src/domain/components/friends/friend-reader';
+import { UserReader } from 'src/domain/components/users/user-reader';
+import {
+    FriendRequestItemDto,
+    GetFriendRequestsResponseDto,
+} from 'src/presentation/dto/friends/response/get-friend-request-list.response';
 
 @Injectable()
 export class FriendsService {
     constructor(
+        private readonly friendReader: FriendReader,
         private readonly friendWrite: FriendWriter,
         private readonly friendChecker: FriendChecker,
+        private readonly userReader: UserReader,
     ) {}
 
     async sendFriendRequest(
@@ -25,5 +38,49 @@ export class FriendsService {
         const stdDate = new Date();
         const friend = FriendEntity.create(prototype, v4, stdDate);
         await this.friendWrite.create(friend);
+    }
+
+    async getFriendRequestList(
+        userId: string,
+        direction: FriendRequestDirection,
+        limit: number,
+        cursor?: string,
+    ): Promise<GetFriendRequestsResponseDto> {
+        const { data: requestList, nextCursor } =
+            await this.friendReader.readFriendsRequests(
+                userId,
+                direction,
+                limit,
+                cursor,
+            );
+
+        if (!requestList || requestList.length === 0) {
+            return { data: [], nextCursor: null };
+        }
+
+        const responseData: FriendRequestItemDto[] = [];
+
+        for (const req of requestList) {
+            const friendUserId =
+                direction === 'received'
+                    ? (req as ReceivedFriendRequestsData).senderId
+                    : (req as SentFriendRequestsData).receiverId;
+
+            const userProfile = await this.userReader.readProfile(friendUserId);
+
+            if (userProfile) {
+                responseData.push({
+                    id: req.id,
+                    user: {
+                        id: userProfile.id,
+                        nickname: userProfile.nickname,
+                        tag: userProfile.tag,
+                        avatarKey: userProfile.avatarKey,
+                    },
+                });
+            }
+        }
+
+        return { data: responseData, nextCursor };
     }
 }

--- a/src/domain/types/friend.types.ts
+++ b/src/domain/types/friend.types.ts
@@ -1,4 +1,5 @@
 export type FriendStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED';
+export type FriendRequestDirection = 'sent' | 'received';
 
 export interface FriendPrototype {
     readonly senderId: string;
@@ -10,4 +11,25 @@ export interface FriendData {
     readonly senderId: string;
     readonly receiverId: string;
     readonly status: FriendStatus;
+}
+export interface ReceivedFriendRequestsData {
+    readonly id: string;
+    readonly senderId: string;
+    readonly createdAt: Date;
+}
+
+export interface SentFriendRequestsData {
+    readonly id: string;
+    readonly receiverId: string;
+    readonly createdAt: Date;
+}
+
+export interface ReceivedPaginatedFriendRequests {
+    readonly data: ReceivedFriendRequestsData[];
+    readonly nextCursor: string | null;
+}
+
+export interface SentPaginatedFriendRequests {
+    readonly data: SentFriendRequestsData[];
+    readonly nextCursor: string | null;
 }

--- a/src/domain/types/friend.types.ts
+++ b/src/domain/types/friend.types.ts
@@ -12,24 +12,21 @@ export interface FriendData {
     readonly receiverId: string;
     readonly status: FriendStatus;
 }
-export interface ReceivedFriendRequestsData {
+
+export interface FriendInfo {
     readonly id: string;
-    readonly senderId: string;
+    readonly nickname: string;
+    readonly tag: string;
+    readonly avatarKey: string;
+}
+
+export interface FriendRequestsData {
+    readonly id: string;
+    readonly user: FriendInfo;
     readonly createdAt: Date;
 }
 
-export interface SentFriendRequestsData {
-    readonly id: string;
-    readonly receiverId: string;
-    readonly createdAt: Date;
-}
-
-export interface ReceivedPaginatedFriendRequests {
-    readonly data: ReceivedFriendRequestsData[];
-    readonly nextCursor: string | null;
-}
-
-export interface SentPaginatedFriendRequests {
-    readonly data: SentFriendRequestsData[];
+export interface PaginatedFriendRequests {
+    readonly data: FriendRequestsData[];
     readonly nextCursor: string | null;
 }

--- a/src/infrastructure/repositories/friend-prisma.repository.ts
+++ b/src/infrastructure/repositories/friend-prisma.repository.ts
@@ -2,7 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { FriendRepository } from 'src/domain/interface/friend.repository';
 import { PrismaService } from '../prisma/prisma.service';
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
-import { FriendData } from 'src/domain/types/friend.types';
+import {
+    FriendData,
+    ReceivedPaginatedFriendRequests,
+    SentPaginatedFriendRequests,
+} from 'src/domain/types/friend.types';
 
 @Injectable()
 export class FriendPrismaRepository implements FriendRepository {
@@ -34,5 +38,55 @@ export class FriendPrismaRepository implements FriendRepository {
                 ],
             },
         });
+    }
+
+    async findReceivedRequestsByUserId(
+        userId: string,
+        limit: number,
+        cursor?: string,
+    ): Promise<ReceivedPaginatedFriendRequests> {
+        const cursorOption = cursor ? { id: cursor } : undefined;
+
+        const requests = await this.prisma.friendRequest.findMany({
+            select: { id: true, senderId: true, createdAt: true },
+            where: { receiverId: userId, status: 'PENDING', deletedAt: null },
+            orderBy: [{ createdAt: 'desc' }, { id: 'asc' }],
+            take: limit + 1,
+            cursor: cursorOption,
+            skip: cursor ? 1 : 0,
+        });
+
+        let nextCursor: string | null = null;
+        if (requests.length > limit) {
+            const nextItem = requests.pop();
+            nextCursor = nextItem?.id ?? null;
+        }
+
+        return { data: requests, nextCursor };
+    }
+
+    async findSentRequestsByUserId(
+        userId: string,
+        limit: number,
+        cursor?: string,
+    ): Promise<SentPaginatedFriendRequests> {
+        const cursorOption = cursor ? { id: cursor } : undefined;
+
+        const requests = await this.prisma.friendRequest.findMany({
+            select: { id: true, receiverId: true, createdAt: true },
+            where: { senderId: userId, status: 'PENDING', deletedAt: null },
+            orderBy: [{ createdAt: 'desc' }, { id: 'asc' }],
+            take: limit + 1,
+            cursor: cursorOption,
+            skip: cursor ? 1 : 0,
+        });
+
+        let nextCursor: string | null = null;
+        if (requests.length > limit) {
+            const nextItem = requests.pop();
+            nextCursor = nextItem?.id ?? null;
+        }
+
+        return { data: requests, nextCursor };
     }
 }

--- a/src/modules/friends/friends.module.ts
+++ b/src/modules/friends/friends.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { FriendsComponentModule } from './friends-component.module';
 import { FriendsController } from 'src/presentation/controller/friends/friends.controller';
 import { FriendsService } from 'src/domain/services/friends/friends.service';
+import { UserComponentModule } from '../users/users-component.module';
 
 @Module({
-    imports: [FriendsComponentModule],
+    imports: [FriendsComponentModule, UserComponentModule],
     controllers: [FriendsController],
     providers: [FriendsService],
 })

--- a/src/presentation/controller/friends/friends.controller.ts
+++ b/src/presentation/controller/friends/friends.controller.ts
@@ -1,14 +1,26 @@
 import {
     Body,
     Controller,
+    Get,
     HttpCode,
     HttpStatus,
     Post,
+    Query,
     UseGuards,
 } from '@nestjs/common';
+import {
+    ApiBearerAuth,
+    ApiOperation,
+    ApiQuery,
+    ApiResponse,
+} from '@nestjs/swagger';
 import { CurrentUser } from 'src/common/decorator/current-user.decorator';
 import { AuthGuard } from 'src/common/guard/auth.guard';
 import { FriendsService } from 'src/domain/services/friends/friends.service';
+import {
+    GetFriendRequestListRequest,
+    GetFriendRequestsResponseDto,
+} from 'src/presentation/dto/friends';
 import { SendFriendRequest } from 'src/presentation/dto/friends/request/send-friend.request';
 
 @Controller('friends')
@@ -23,5 +35,41 @@ export class FriendsController {
         @Body() dto: SendFriendRequest,
     ): Promise<void> {
         await this.friendsService.sendFriendRequest(userId, dto.targetUserId);
+    }
+
+    @ApiOperation({
+        summary: '친구 요청 목록 조회 (받은 요청 / 보낸 요청) - 페이지네이션',
+    })
+    @ApiQuery({ type: GetFriendRequestListRequest })
+    @ApiResponse({
+        status: 200,
+        description:
+            '조회 성공. 각 요청 항목에는 관련된 상대방 사용자 정보가 user 필드에 포함됩니다.', // 설명 업데이트
+        type: GetFriendRequestsResponseDto,
+    })
+    @ApiResponse({
+        status: 400,
+        description: '잘못된 요청 파라미터 (direction, limit, cursor)',
+    })
+    @ApiResponse({
+        status: 401,
+        description: '인증 실패 (토큰 누락 또는 만료)',
+    })
+    @ApiBearerAuth()
+    @UseGuards(AuthGuard)
+    @Get('requests')
+    async getFriendRequests(
+        @CurrentUser() userId: string,
+        @Query() dto: GetFriendRequestListRequest,
+    ): Promise<GetFriendRequestsResponseDto> {
+        const limit = dto.limit ?? 10;
+        const { direction, cursor } = dto;
+
+        return await this.friendsService.getFriendRequestList(
+            userId,
+            direction,
+            limit,
+            cursor,
+        );
     }
 }

--- a/src/presentation/controller/users/users.controller.ts
+++ b/src/presentation/controller/users/users.controller.ts
@@ -14,7 +14,6 @@ import {
     ApiBody,
     ApiOperation,
     ApiParam,
-    ApiQuery,
     ApiResponse,
     ApiTags,
 } from '@nestjs/swagger';
@@ -41,30 +40,6 @@ export class UserController {
         summary: '유저 검색 (닉네임 또는 태그)',
         description:
             '닉네임 또는 태그를 기준으로 사용자를 검색합니다.(커서기반 페이지네이션)',
-    })
-    @ApiQuery({
-        name: 'search',
-        description: '검색할 닉네임 또는 태그',
-        required: true,
-        type: String,
-    })
-    @ApiQuery({
-        name: 'varient',
-        enum: ['NICKNAME', 'TAG'],
-        description: '검색 기준 (닉네임 또는 태그)',
-        required: true,
-    })
-    @ApiQuery({
-        name: 'limit',
-        description: '한 페이지에 보여줄 유저 수 (기본값 10)',
-        required: false,
-        type: Number,
-    })
-    @ApiQuery({
-        name: 'cursor',
-        description: '다음 페이지 시작점 ID',
-        required: false,
-        type: String,
     })
     @ApiResponse({
         status: 200,

--- a/src/presentation/dto/friends/index.ts
+++ b/src/presentation/dto/friends/index.ts
@@ -1,0 +1,4 @@
+export * from './request/get-friend-request-list.request';
+export * from './request/send-friend.request';
+
+export * from './response/get-friend-request-list.response';

--- a/src/presentation/dto/friends/request/get-friend-request-list.request.ts
+++ b/src/presentation/dto/friends/request/get-friend-request-list.request.ts
@@ -1,0 +1,36 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export enum FriendRequestDirection {
+    SENT = 'sent',
+    RECEIVED = 'received',
+}
+
+export class GetFriendRequestListRequest {
+    @ApiProperty({
+        enum: FriendRequestDirection,
+        description:
+            '조회할 친구 요청 방향 (sent: 보낸 요청, received: 받은 요청)',
+        required: true,
+        example: FriendRequestDirection.SENT,
+    })
+    @IsEnum(FriendRequestDirection)
+    readonly direction: FriendRequestDirection;
+
+    @ApiPropertyOptional({
+        description: '페이지네이션 커서 (Friend Request ID',
+    })
+    @IsOptional()
+    @IsString()
+    readonly cursor?: string;
+
+    @ApiPropertyOptional({
+        description: '한 페이지에 가져올 항목 수 (기본값: 10)',
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    readonly limit?: number = 10;
+}

--- a/src/presentation/dto/friends/response/get-friend-request-list.response.ts
+++ b/src/presentation/dto/friends/response/get-friend-request-list.response.ts
@@ -21,6 +21,9 @@ export class FriendRequestItemDto {
             '상대방 유저 정보 (direction=received 이면 보낸 사람, direction=sent 이면 받은 사람)',
     })
     readonly user: FriendRequestUserInfoDto;
+
+    @ApiProperty({ description: '친구 요청 보낸/받은 시간' })
+    readonly createdAt: Date;
 }
 
 export class GetFriendRequestsResponseDto {

--- a/src/presentation/dto/friends/response/get-friend-request-list.response.ts
+++ b/src/presentation/dto/friends/response/get-friend-request-list.response.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class FriendRequestUserInfoDto {
+    @ApiProperty({ description: '유저 ID' })
+    readonly id: string;
+    @ApiProperty({ description: '유저 닉네임' })
+    readonly nickname: string;
+    @ApiProperty({ description: '유저 태그' })
+    readonly tag: string;
+    @ApiProperty({ description: '유저 아바타 키' })
+    readonly avatarKey: string;
+}
+
+export class FriendRequestItemDto {
+    @ApiProperty({ description: '친구 요청 ID' })
+    readonly id: string;
+
+    @ApiProperty({
+        type: FriendRequestUserInfoDto,
+        description:
+            '상대방 유저 정보 (direction=received 이면 보낸 사람, direction=sent 이면 받은 사람)',
+    })
+    readonly user: FriendRequestUserInfoDto;
+}
+
+export class GetFriendRequestsResponseDto {
+    @ApiProperty({
+        type: [FriendRequestItemDto],
+        description: '친구 요청 목록',
+    })
+    readonly data: FriendRequestItemDto[];
+
+    @ApiProperty({
+        description: '다음 페이지 시작점 ID, 마지막 페이지인 경우 null',
+        example: '123e4567-e89b-12d3-a456-426614174000',
+        nullable: true,
+        required: false,
+    })
+    readonly nextCursor: string | null;
+}

--- a/src/presentation/dto/users/request/search-users.request.ts
+++ b/src/presentation/dto/users/request/search-users.request.ts
@@ -8,20 +8,38 @@ export enum Varient {
 }
 
 export class SearchUsersRequest {
-    @ApiProperty()
+    @ApiProperty({
+        name: 'search',
+        description: '검색할 닉네임 또는 태그',
+        type: String,
+    })
     @IsString()
     readonly search: string;
 
-    @ApiProperty({ enum: Varient })
+    @ApiProperty({
+        name: 'varient',
+        enum: Varient,
+        description: '검색 기준 (닉네임 또는 태그)',
+    })
     @IsEnum(Varient)
     readonly varient: Varient;
 
-    @ApiProperty()
+    @ApiProperty({
+        name: 'limit',
+        description: '한 페이지에 보여줄 유저 수 (기본값 10)',
+        required: false,
+        type: Number,
+    })
     @IsString()
     @IsOptional()
     readonly cursor?: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        name: 'cursor',
+        description: '다음 페이지 시작점 ID',
+        required: false,
+        type: String,
+    })
     @IsOptional()
     @Type(() => Number)
     @IsInt()

--- a/test/e2e/app.e2e-spec.ts
+++ b/test/e2e/app.e2e-spec.ts
@@ -15,6 +15,10 @@ describe('AppController (e2e)', () => {
         await app.init();
     });
 
+    afterAll(() => {
+        app.close();
+    });
+
     it('/ (GET)', () => {
         return request(app.getHttpServer())
             .get('/')

--- a/test/e2e/friend.e2e-spec.ts
+++ b/test/e2e/friend.e2e-spec.ts
@@ -1,5 +1,4 @@
 import * as request from 'supertest';
-
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppModule } from 'src/app.module';
@@ -12,16 +11,12 @@ import {
     FriendRequestDirection,
     GetFriendRequestsResponseDto,
 } from 'src/presentation/dto/friends';
+import { UserEntity } from 'src/domain/entities/user/user.entity';
+import { FriendRequest as FriendRequestPrisma } from '@prisma/client';
 
 describe('FriendController (e2e)', () => {
     let app: INestApplication;
     let prisma: PrismaService;
-    let loggedInUser: {
-        userId: string;
-        accessToken: string;
-        nickname: string;
-        tag: string;
-    };
 
     beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -31,59 +26,52 @@ describe('FriendController (e2e)', () => {
         app = moduleFixture.createNestApplication();
         prisma = moduleFixture.get<PrismaService>(PrismaService);
         await app.init();
-
-        loggedInUser = await login(app);
     });
 
     afterAll(async () => {
-        await prisma.user.deleteMany({
-            where: { email: 'metamorn@metamorn.com' },
-        });
         app.close();
     });
 
     afterEach(async () => {
         await prisma.friendRequest.deleteMany();
-        await prisma.user.deleteMany({
-            where: { email: { not: 'metamorn@metamorn.com' } },
-        });
+        await prisma.user.deleteMany();
     });
 
     describe('POST /friends/requests', () => {
         it('친구 요청을 전송 정상 동작', async () => {
-            const { accessToken, userId } = await login(app);
+            const currentUser = await login(app);
 
-            const recivedUser = await prisma.user.create({
+            const receivedUser = await prisma.user.create({
                 data: generateUserEntity(
-                    'reciver@email.com',
+                    'receiver@email.com',
                     'testNickname',
                     'testTag',
                 ),
             });
 
             const dto: SendFriendRequest = {
-                targetUserId: recivedUser.id,
+                targetUserId: receivedUser.id,
             };
 
             const response = await request(app.getHttpServer())
                 .post('/friends/requests')
                 .send(dto)
-                .set('Authorization', accessToken);
+                .set('Authorization', currentUser.accessToken);
 
             const { status } = response;
             const createdFriendRequest = await prisma.friendRequest.findFirst({
                 where: {
-                    senderId: userId,
-                    receiverId: recivedUser.id,
+                    senderId: currentUser.userId,
+                    receiverId: receivedUser.id,
                 },
             });
 
-            expect(status).toBe(204);
+            expect(status).toBe(HttpStatus.NO_CONTENT);
             expect(createdFriendRequest).not.toBeNull();
         });
 
         it('이미 보낸 요청이 있을 경우 409 Conflict 에러 반환', async () => {
-            const { accessToken, userId } = await login(app);
+            const currentUser = await login(app);
 
             const receivedUser = await prisma.user.create({
                 data: generateUserEntity(
@@ -100,7 +88,7 @@ describe('FriendController (e2e)', () => {
             await prisma.friendRequest.create({
                 data: {
                     id: v4(),
-                    senderId: userId,
+                    senderId: currentUser.userId,
                     receiverId: receivedUser.id,
                     status: 'PENDING',
                     createdAt: new Date(),
@@ -111,13 +99,13 @@ describe('FriendController (e2e)', () => {
             const response = await request(app.getHttpServer())
                 .post('/friends/requests')
                 .send(dto)
-                .set('Authorization', accessToken);
+                .set('Authorization', currentUser.accessToken);
 
             expect(response.status).toBe(HttpStatus.CONFLICT);
 
             const requestCount = await prisma.friendRequest.count({
                 where: {
-                    senderId: userId,
+                    senderId: currentUser.userId,
                     receiverId: receivedUser.id,
                 },
             });
@@ -125,33 +113,28 @@ describe('FriendController (e2e)', () => {
         });
 
         it('자신에게 친구 요청을 보낼 경우 400 Bad Request 에러 반환', async () => {
-            const { accessToken, userId } = await login(app);
+            const currentUser = await login(app);
 
             const dto: SendFriendRequest = {
-                targetUserId: userId,
+                targetUserId: currentUser.userId,
             };
 
             const response = await request(app.getHttpServer())
                 .post('/friends/requests')
                 .send(dto)
-                .set('Authorization', accessToken);
+                .set('Authorization', currentUser.accessToken);
 
             expect(response.status).toBe(HttpStatus.BAD_REQUEST);
         });
     });
 
-    /***********************************************************/
-    //!(친구요청 목록 조회) ai로 테스트 코드 작성 검증 필요
-    /***********************************************************/
-
     describe('GET /friends/requests - 친구 요청 목록 조회 (정상 동작)', () => {
-        let userB: any; // 테스트용 유저 B
-        let userC: any; // 테스트용 유저 C
-        let requestBtoA: any; // B -> A(로그인 유저) 요청
-        let requestAtoC: any; // A(로그인 유저) -> C 요청
+        let userB: UserEntity;
+        let userC: UserEntity;
+        let requestBtoA: FriendRequestPrisma;
+        let requestAtoC: FriendRequestPrisma;
 
-        // 각 'it' 테스트 실행 전에 필요한 유저와 친구 요청 데이터를 생성하는 헬퍼 함수
-        const setupTestData = async () => {
+        const setupTestData = async (currentUserId: string) => {
             userB = await prisma.user.create({
                 data: generateUserEntity('userB@test.com', 'UserB', 'tagB'),
             });
@@ -159,23 +142,21 @@ describe('FriendController (e2e)', () => {
                 data: generateUserEntity('userC@test.com', 'UserC', 'tagC'),
             });
 
-            // B가 로그인한 유저(A)에게 보낸 요청 생성
             requestBtoA = await prisma.friendRequest.create({
                 data: {
                     id: v4(),
                     senderId: userB.id,
-                    receiverId: loggedInUser.userId,
+                    receiverId: currentUserId,
                     status: 'PENDING',
                     createdAt: new Date(),
                     updatedAt: new Date(),
                 },
             });
 
-            // 로그인한 유저(A)가 C에게 보낸 요청 생성
             requestAtoC = await prisma.friendRequest.create({
                 data: {
                     id: v4(),
-                    senderId: loggedInUser.userId,
+                    senderId: currentUserId,
                     receiverId: userC.id,
                     status: 'PENDING',
                     createdAt: new Date(),
@@ -185,90 +166,88 @@ describe('FriendController (e2e)', () => {
         };
 
         it('받은 친구 요청 목록을 정상적으로 조회한다', async () => {
-            await setupTestData(); // 테스트 데이터 생성
+            const currentUser = await login(app);
+            await setupTestData(currentUser.userId);
 
-            // API 호출: 받은 요청 목록 조회 (direction=received)
             const response = await request(app.getHttpServer())
                 .get('/friends/requests')
-                .query({ direction: FriendRequestDirection.RECEIVED }) // 받은 요청 명시
-                .set('Authorization', loggedInUser.accessToken) // 로그인 토큰 설정
-                .expect(HttpStatus.OK); // 200 OK 상태 코드 기대
+                .query({ direction: FriendRequestDirection.RECEIVED })
+                .set('Authorization', currentUser.accessToken)
+                .expect(HttpStatus.OK);
 
-            // 응답 본문 검증
             const body = response.body as GetFriendRequestsResponseDto;
-            expect(body.data).toHaveLength(1); // B -> A 요청 1개 확인
-            expect(body.data[0].id).toBe(requestBtoA.id); // 요청 ID 확인
-            expect(body.data[0].user.id).toBe(userB.id); // 보낸 사람(UserB) ID 확인
-            expect(body.data[0].user.nickname).toBe(userB.nickname); // 보낸 사람 닉네임 확인
-            expect(body.data[0].user.tag).toBe(userB.tag); // 보낸 사람 태그 확인
-            expect(body.nextCursor).toBeNull(); // 다음 페이지 없으므로 커서는 null
+            expect(body.data).toHaveLength(1);
+            const requestItem = body.data[0];
+            expect(requestItem.id).toBe(requestBtoA.id);
+            expect(requestItem.user.id).toBe(userB.id);
+            expect(requestItem.user.nickname).toBe(userB.nickname);
+            expect(requestItem.user.tag).toBe(userB.tag);
+            expect(body.nextCursor).toBeNull();
         });
 
         it('보낸 친구 요청 목록을 정상적으로 조회한다', async () => {
-            await setupTestData(); // 테스트 데이터 생성
+            const currentUser = await login(app);
+            await setupTestData(currentUser.userId);
 
-            // API 호출: 보낸 요청 목록 조회 (direction=sent)
             const response = await request(app.getHttpServer())
                 .get('/friends/requests')
-                .query({ direction: FriendRequestDirection.SENT }) // 보낸 요청 명시
-                .set('Authorization', loggedInUser.accessToken) // 로그인 토큰 설정
-                .expect(HttpStatus.OK); // 200 OK 상태 코드 기대
+                .query({ direction: FriendRequestDirection.SENT })
+                .set('Authorization', currentUser.accessToken)
+                .expect(HttpStatus.OK);
 
-            // 응답 본문 검증
             const body = response.body as GetFriendRequestsResponseDto;
-            expect(body.data).toHaveLength(1); // A -> C 요청 1개 확인
-            expect(body.data[0].id).toBe(requestAtoC.id); // 요청 ID 확인
-            expect(body.data[0].user.id).toBe(userC.id); // 받은 사람(UserC) ID 확인
-            expect(body.data[0].user.nickname).toBe(userC.nickname); // 받은 사람 닉네임 확인
-            expect(body.data[0].user.tag).toBe(userC.tag); // 받은 사람 태그 확인
-            expect(body.nextCursor).toBeNull(); // 다음 페이지 없으므로 커서는 null
+            expect(body.data).toHaveLength(1);
+            const requestItem = body.data[0];
+            expect(requestItem.id).toBe(requestAtoC.id);
+            expect(requestItem.user.id).toBe(userC.id);
+            expect(requestItem.user.nickname).toBe(userC.nickname);
+            expect(requestItem.user.tag).toBe(userC.tag);
+            expect(body.nextCursor).toBeNull();
         });
 
         it('인증 토큰 없이 요청 시 401 Unauthorized 에러를 반환한다', async () => {
             await request(app.getHttpServer())
                 .get('/friends/requests')
                 .query({ direction: FriendRequestDirection.RECEIVED })
-                // .set('Authorization', ...) // 인증 헤더 없음
-                .expect(HttpStatus.UNAUTHORIZED); // 401 상태 코드 기대
+                .expect(HttpStatus.UNAUTHORIZED);
         });
 
         it('잘못된 direction 값을 사용하면 400 Bad Request 에러를 반환한다', async () => {
+            const currentUser = await login(app);
             await request(app.getHttpServer())
                 .get('/friends/requests')
-                .query({ direction: 'invalid_direction' }) // 유효하지 않은 direction 값
-                .set('Authorization', loggedInUser.accessToken)
-                .expect(HttpStatus.BAD_REQUEST); // 400 상태 코드 기대
+                .query({ direction: 'invalid_direction' })
+                .set('Authorization', currentUser.accessToken)
+                .expect(HttpStatus.BAD_REQUEST);
         });
 
         it('direction 파라미터가 누락되면 400 Bad Request 에러를 반환한다', async () => {
+            const currentUser = await login(app);
             await request(app.getHttpServer())
                 .get('/friends/requests')
-                // direction 파라미터 없음
-                .set('Authorization', loggedInUser.accessToken)
-                .expect(HttpStatus.BAD_REQUEST); // 400 상태 코드 기대
+                .set('Authorization', currentUser.accessToken)
+                .expect(HttpStatus.BAD_REQUEST);
         });
 
         it('limit 파라미터에 숫자가 아닌 값을 넣으면 400 Bad Request 에러를 반환한다', async () => {
+            const currentUser = await login(app);
             await request(app.getHttpServer())
                 .get('/friends/requests')
                 .query({
                     direction: FriendRequestDirection.RECEIVED,
                     limit: 'abc',
-                }) // 숫자가 아닌 limit 값
-                .set('Authorization', loggedInUser.accessToken)
-                .expect(HttpStatus.BAD_REQUEST); // 400 상태 코드 기대
+                })
+                .set('Authorization', currentUser.accessToken)
+                .expect(HttpStatus.BAD_REQUEST);
         });
 
         it('limit 파라미터에 0 이하의 값을 넣으면 400 Bad Request 에러를 반환한다', async () => {
+            const currentUser = await login(app);
             await request(app.getHttpServer())
                 .get('/friends/requests')
-                .query({ direction: FriendRequestDirection.RECEIVED, limit: 0 }) // 0 이하의 limit 값
-                .set('Authorization', loggedInUser.accessToken)
-                .expect(HttpStatus.BAD_REQUEST); // 400 상태 코드 기대
+                .query({ direction: FriendRequestDirection.RECEIVED, limit: 0 })
+                .set('Authorization', currentUser.accessToken)
+                .expect(HttpStatus.BAD_REQUEST);
         });
-
-        // 참고: cursor 값 자체의 유효성 검증 (예: UUID 형식)은 DTO나 파이프 단계에서 처리될 수 있으며,
-        // 여기서는 주로 쿼리 파라미터 자체의 필수 여부 및 타입/범위 검증에 초점을 맞춥니다.
-        // 만약 cursor 값 형식 검증이 중요하다면 해당 케이스도 추가할 수 있습니다.
     });
 });

--- a/test/e2e/friend.e2e-spec.ts
+++ b/test/e2e/friend.e2e-spec.ts
@@ -8,10 +8,20 @@ import { generateUserEntity } from 'test/helper/generators';
 import { login } from 'test/helper/login';
 import { SendFriendRequest } from 'src/presentation/dto/friends/request/send-friend.request';
 import { v4 } from 'uuid';
+import {
+    FriendRequestDirection,
+    GetFriendRequestsResponseDto,
+} from 'src/presentation/dto/friends';
 
 describe('FriendController (e2e)', () => {
     let app: INestApplication;
     let prisma: PrismaService;
+    let loggedInUser: {
+        userId: string;
+        accessToken: string;
+        nickname: string;
+        tag: string;
+    };
 
     beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -21,14 +31,22 @@ describe('FriendController (e2e)', () => {
         app = moduleFixture.createNestApplication();
         prisma = moduleFixture.get<PrismaService>(PrismaService);
         await app.init();
+
+        loggedInUser = await login(app);
     });
 
-    afterAll(() => {
+    afterAll(async () => {
+        await prisma.user.deleteMany({
+            where: { email: 'metamorn@metamorn.com' },
+        });
         app.close();
     });
 
     afterEach(async () => {
         await prisma.friendRequest.deleteMany();
+        await prisma.user.deleteMany({
+            where: { email: { not: 'metamorn@metamorn.com' } },
+        });
     });
 
     describe('POST /friends/requests', () => {
@@ -118,7 +136,139 @@ describe('FriendController (e2e)', () => {
                 .send(dto)
                 .set('Authorization', accessToken);
 
-            expect(response.status).toBe(HttpStatus.BAD_REQUEST); // 400 확인
+            expect(response.status).toBe(HttpStatus.BAD_REQUEST);
         });
+    });
+
+    /***********************************************************/
+    //!(친구요청 목록 조회) ai로 테스트 코드 작성 검증 필요
+    /***********************************************************/
+
+    describe('GET /friends/requests - 친구 요청 목록 조회 (정상 동작)', () => {
+        let userB: any; // 테스트용 유저 B
+        let userC: any; // 테스트용 유저 C
+        let requestBtoA: any; // B -> A(로그인 유저) 요청
+        let requestAtoC: any; // A(로그인 유저) -> C 요청
+
+        // 각 'it' 테스트 실행 전에 필요한 유저와 친구 요청 데이터를 생성하는 헬퍼 함수
+        const setupTestData = async () => {
+            userB = await prisma.user.create({
+                data: generateUserEntity('userB@test.com', 'UserB', 'tagB'),
+            });
+            userC = await prisma.user.create({
+                data: generateUserEntity('userC@test.com', 'UserC', 'tagC'),
+            });
+
+            // B가 로그인한 유저(A)에게 보낸 요청 생성
+            requestBtoA = await prisma.friendRequest.create({
+                data: {
+                    id: v4(),
+                    senderId: userB.id,
+                    receiverId: loggedInUser.userId,
+                    status: 'PENDING',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+            });
+
+            // 로그인한 유저(A)가 C에게 보낸 요청 생성
+            requestAtoC = await prisma.friendRequest.create({
+                data: {
+                    id: v4(),
+                    senderId: loggedInUser.userId,
+                    receiverId: userC.id,
+                    status: 'PENDING',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+            });
+        };
+
+        it('받은 친구 요청 목록을 정상적으로 조회한다', async () => {
+            await setupTestData(); // 테스트 데이터 생성
+
+            // API 호출: 받은 요청 목록 조회 (direction=received)
+            const response = await request(app.getHttpServer())
+                .get('/friends/requests')
+                .query({ direction: FriendRequestDirection.RECEIVED }) // 받은 요청 명시
+                .set('Authorization', loggedInUser.accessToken) // 로그인 토큰 설정
+                .expect(HttpStatus.OK); // 200 OK 상태 코드 기대
+
+            // 응답 본문 검증
+            const body = response.body as GetFriendRequestsResponseDto;
+            expect(body.data).toHaveLength(1); // B -> A 요청 1개 확인
+            expect(body.data[0].id).toBe(requestBtoA.id); // 요청 ID 확인
+            expect(body.data[0].user.id).toBe(userB.id); // 보낸 사람(UserB) ID 확인
+            expect(body.data[0].user.nickname).toBe(userB.nickname); // 보낸 사람 닉네임 확인
+            expect(body.data[0].user.tag).toBe(userB.tag); // 보낸 사람 태그 확인
+            expect(body.nextCursor).toBeNull(); // 다음 페이지 없으므로 커서는 null
+        });
+
+        it('보낸 친구 요청 목록을 정상적으로 조회한다', async () => {
+            await setupTestData(); // 테스트 데이터 생성
+
+            // API 호출: 보낸 요청 목록 조회 (direction=sent)
+            const response = await request(app.getHttpServer())
+                .get('/friends/requests')
+                .query({ direction: FriendRequestDirection.SENT }) // 보낸 요청 명시
+                .set('Authorization', loggedInUser.accessToken) // 로그인 토큰 설정
+                .expect(HttpStatus.OK); // 200 OK 상태 코드 기대
+
+            // 응답 본문 검증
+            const body = response.body as GetFriendRequestsResponseDto;
+            expect(body.data).toHaveLength(1); // A -> C 요청 1개 확인
+            expect(body.data[0].id).toBe(requestAtoC.id); // 요청 ID 확인
+            expect(body.data[0].user.id).toBe(userC.id); // 받은 사람(UserC) ID 확인
+            expect(body.data[0].user.nickname).toBe(userC.nickname); // 받은 사람 닉네임 확인
+            expect(body.data[0].user.tag).toBe(userC.tag); // 받은 사람 태그 확인
+            expect(body.nextCursor).toBeNull(); // 다음 페이지 없으므로 커서는 null
+        });
+
+        it('인증 토큰 없이 요청 시 401 Unauthorized 에러를 반환한다', async () => {
+            await request(app.getHttpServer())
+                .get('/friends/requests')
+                .query({ direction: FriendRequestDirection.RECEIVED })
+                // .set('Authorization', ...) // 인증 헤더 없음
+                .expect(HttpStatus.UNAUTHORIZED); // 401 상태 코드 기대
+        });
+
+        it('잘못된 direction 값을 사용하면 400 Bad Request 에러를 반환한다', async () => {
+            await request(app.getHttpServer())
+                .get('/friends/requests')
+                .query({ direction: 'invalid_direction' }) // 유효하지 않은 direction 값
+                .set('Authorization', loggedInUser.accessToken)
+                .expect(HttpStatus.BAD_REQUEST); // 400 상태 코드 기대
+        });
+
+        it('direction 파라미터가 누락되면 400 Bad Request 에러를 반환한다', async () => {
+            await request(app.getHttpServer())
+                .get('/friends/requests')
+                // direction 파라미터 없음
+                .set('Authorization', loggedInUser.accessToken)
+                .expect(HttpStatus.BAD_REQUEST); // 400 상태 코드 기대
+        });
+
+        it('limit 파라미터에 숫자가 아닌 값을 넣으면 400 Bad Request 에러를 반환한다', async () => {
+            await request(app.getHttpServer())
+                .get('/friends/requests')
+                .query({
+                    direction: FriendRequestDirection.RECEIVED,
+                    limit: 'abc',
+                }) // 숫자가 아닌 limit 값
+                .set('Authorization', loggedInUser.accessToken)
+                .expect(HttpStatus.BAD_REQUEST); // 400 상태 코드 기대
+        });
+
+        it('limit 파라미터에 0 이하의 값을 넣으면 400 Bad Request 에러를 반환한다', async () => {
+            await request(app.getHttpServer())
+                .get('/friends/requests')
+                .query({ direction: FriendRequestDirection.RECEIVED, limit: 0 }) // 0 이하의 limit 값
+                .set('Authorization', loggedInUser.accessToken)
+                .expect(HttpStatus.BAD_REQUEST); // 400 상태 코드 기대
+        });
+
+        // 참고: cursor 값 자체의 유효성 검증 (예: UUID 형식)은 DTO나 파이프 단계에서 처리될 수 있으며,
+        // 여기서는 주로 쿼리 파라미터 자체의 필수 여부 및 타입/범위 검증에 초점을 맞춥니다.
+        // 만약 cursor 값 형식 검증이 중요하다면 해당 케이스도 추가할 수 있습니다.
     });
 });


### PR DESCRIPTION
## 작업 이슈
- #30 
## 작업 내용
- 보내거나 받은 친구요청을 조회하는 기능을 구현했습니다.
- 해당 기능의 e2e 테스트 코드를 작성했습니다.
- swagger API도 같이 작성 했습니다.
## 테스트
N+1 개선 전 후 비교 (20회 실행 중앙값)
친구 요청 수 | 개선 전 | 개선 후 | 속도 향상
-- | -- | -- | --
1개 | 1.19ms / 2쿼리 | 1.11ms / 2쿼리 | 1.07배
10개 | 6.08ms / 11쿼리 | 1.12ms / 2쿼리 | 5.43배
50개 | 33.54ms / 51쿼리 | 1.99ms / 2쿼리 | 16.85배
100개 | 32.42ms / 101쿼리 | 1.20ms / 2쿼리 | 27.02배
