### PR TITLE
아바타 변경 기능 구현 및 업데이트 관련 기능들 리팩토링

### DIFF
--- a/src/domain/components/users/user-writer.ts
+++ b/src/domain/components/users/user-writer.ts
@@ -20,4 +20,8 @@ export class UserWriter {
     async updateTag(id: string, tag: string) {
         await this.userRepository.update(id, { tag });
     }
+
+    async updateAvatarKey(id: string, avatarKey: string) {
+        await this.userRepository.update(id, { avatarKey });
+    }
 }

--- a/src/domain/components/users/user-writer.ts
+++ b/src/domain/components/users/user-writer.ts
@@ -13,7 +13,11 @@ export class UserWriter {
         await this.userRepository.save(user);
     }
 
-    async change(user: { id: string; nickname?: string; tag?: string }) {
-        await this.userRepository.update(user);
+    async updateNickname(id: string, nickname: string) {
+        await this.userRepository.update(id, { nickname });
+    }
+
+    async updateTag(id: string, tag: string) {
+        await this.userRepository.update(id, { tag });
     }
 }

--- a/src/domain/interface/user.repository.ts
+++ b/src/domain/interface/user.repository.ts
@@ -16,7 +16,7 @@ export interface UserRepository {
         limit: number,
         cursor?: string,
     ): Promise<PaginatedUsers>;
-    update(data: Partial<UserEntity>): Promise<void>;
+    update(id: string, data: Partial<UserEntity>): Promise<void>;
 }
 
 export const UserRepository = Symbol('UserRepository');

--- a/src/domain/services/users/users.service.ts
+++ b/src/domain/services/users/users.service.ts
@@ -12,11 +12,11 @@ export class UserService {
         private readonly userWriter: UserWriter,
     ) {}
 
-    async updateNickname(userId: string, nickname: string) {
-        await this.userWriter.change({ id: userId, nickname });
+    async changeNickname(userId: string, nickname: string) {
+        await this.userWriter.updateNickname(userId, nickname);
     }
 
-    async updateTag(userId: string, tag: string) {
+    async changeTag(userId: string, tag: string) {
         try {
             const user = await this.userReader.readOneByTag(tag);
 
@@ -32,7 +32,7 @@ export class UserService {
                 e instanceof DomainException &&
                 e.errorType === DomainExceptionType.UserNotFound
             ) {
-                return await this.userWriter.change({ id: userId, tag });
+                return await this.userWriter.updateTag(userId, tag);
             }
             throw e;
         }

--- a/src/domain/services/users/users.service.ts
+++ b/src/domain/services/users/users.service.ts
@@ -37,4 +37,8 @@ export class UserService {
             throw e;
         }
     }
+
+    async changeAvatar(userId: string, avatarKey: string) {
+        await this.userWriter.updateAvatarKey(userId, avatarKey);
+    }
 }

--- a/src/infrastructure/repositories/user-prisma.repository.ts
+++ b/src/infrastructure/repositories/user-prisma.repository.ts
@@ -134,10 +134,15 @@ export class UserPrismaRepository implements UserRepository {
         return { data, nextCursor };
     }
 
-    async update(data: Partial<UserEntity>): Promise<void> {
-        const { id, ...updateData } = data;
+    async update(id: string, data: Partial<UserEntity>): Promise<void> {
+        const { nickname, tag, avatarKey } = data;
+
         await this.prisma.user.update({
-            data: updateData,
+            data: {
+                nickname,
+                tag,
+                avatarKey,
+            },
             where: {
                 id,
             },

--- a/src/presentation/controller/users/users.controller.ts
+++ b/src/presentation/controller/users/users.controller.ts
@@ -32,6 +32,7 @@ import { SearchUserResponse } from 'src/presentation/dto/users/response/search-u
 @ApiResponse({ status: 400, description: '잘못된 요청 데이터 형식' })
 @ApiResponse({ status: 401, description: '인증 실패' })
 @ApiBearerAuth()
+@UseGuards(AuthGuard)
 @Controller('users')
 export class UserController {
     constructor(
@@ -49,7 +50,6 @@ export class UserController {
         description: '검색 성공',
         type: SearchUserResponse,
     })
-    @UseGuards(AuthGuard)
     @Get('search')
     async searchUser(
         @Query() query: SearchUsersRequest,
@@ -69,7 +69,6 @@ export class UserController {
         type: GetUserResponse,
     })
     @ApiResponse({ status: 404, description: '존재하지 않는 사용자' })
-    @UseGuards(AuthGuard)
     @Get('my')
     async getMyProfile(@CurrentUser() userId: string): Promise<GetMyResponse> {
         return await this.userReader.readProfile(userId);
@@ -91,7 +90,6 @@ export class UserController {
         type: GetUserResponse,
     })
     @ApiResponse({ status: 404, description: '존재하지 않는 사용자' })
-    @UseGuards(AuthGuard)
     @Get(':id')
     async getUser(@Param('id') userId: string): Promise<GetUserResponse> {
         return await this.userReader.readProfile(userId);
@@ -102,7 +100,6 @@ export class UserController {
         description: '로그인한 사용자의 닉네임을 변경합니다.',
     })
     @ApiResponse({ status: 204, description: '닉네임 변경 성공 (No Content)' })
-    @UseGuards(AuthGuard)
     @HttpCode(HttpStatus.NO_CONTENT)
     @Patch('nickname')
     async changeNickname(
@@ -118,7 +115,6 @@ export class UserController {
             '로그인한 사용자의 태그를 변경합니다. 태그는 고유해야 합니다.',
     })
     @ApiResponse({ status: 204, description: '태그 변경 성공 (No Content)' })
-    @UseGuards(AuthGuard)
     @HttpCode(HttpStatus.NO_CONTENT)
     @Patch('tag')
     async changeTag(

--- a/src/presentation/controller/users/users.controller.ts
+++ b/src/presentation/controller/users/users.controller.ts
@@ -101,7 +101,6 @@ export class UserController {
         summary: '닉네임 변경',
         description: '로그인한 사용자의 닉네임을 변경합니다.',
     })
-    @ApiBody({ type: ChangeNicknameRequest })
     @ApiResponse({ status: 204, description: '닉네임 변경 성공 (No Content)' })
     @UseGuards(AuthGuard)
     @HttpCode(HttpStatus.NO_CONTENT)
@@ -118,7 +117,6 @@ export class UserController {
         description:
             '로그인한 사용자의 태그를 변경합니다. 태그는 고유해야 합니다.',
     })
-    @ApiBody({ type: ChangeTagRequest })
     @ApiResponse({ status: 204, description: '태그 변경 성공 (No Content)' })
     @UseGuards(AuthGuard)
     @HttpCode(HttpStatus.NO_CONTENT)

--- a/src/presentation/controller/users/users.controller.ts
+++ b/src/presentation/controller/users/users.controller.ts
@@ -106,7 +106,7 @@ export class UserController {
         @Body() dto: ChangeNicknameRequest,
         @CurrentUser() userId: string,
     ) {
-        await this.userService.updateNickname(userId, dto.nickname);
+        await this.userService.changeNickname(userId, dto.nickname);
     }
 
     @ApiOperation({
@@ -121,6 +121,6 @@ export class UserController {
         @Body() dto: ChangeTagRequest,
         @CurrentUser() userId: string,
     ) {
-        await this.userService.updateTag(userId, dto.tag);
+        await this.userService.changeTag(userId, dto.tag);
     }
 }

--- a/src/presentation/controller/users/users.controller.ts
+++ b/src/presentation/controller/users/users.controller.ts
@@ -29,6 +29,9 @@ import { GetUserResponse } from 'src/presentation/dto/users/response/get-user.re
 import { SearchUserResponse } from 'src/presentation/dto/users/response/search-users.response';
 
 @ApiTags('users')
+@ApiResponse({ status: 400, description: '잘못된 요청 데이터 형식' })
+@ApiResponse({ status: 401, description: '인증 실패' })
+@ApiBearerAuth()
 @Controller('users')
 export class UserController {
     constructor(
@@ -46,8 +49,6 @@ export class UserController {
         description: '검색 성공',
         type: SearchUserResponse,
     })
-    @ApiResponse({ status: 400, description: '잘못된 요청 파라미터' })
-    @ApiBearerAuth()
     @UseGuards(AuthGuard)
     @Get('search')
     async searchUser(
@@ -67,9 +68,7 @@ export class UserController {
         description: '조회 성공',
         type: GetUserResponse,
     })
-    @ApiResponse({ status: 401, description: '인증 실패' })
     @ApiResponse({ status: 404, description: '존재하지 않는 사용자' })
-    @ApiBearerAuth()
     @UseGuards(AuthGuard)
     @Get('my')
     async getMyProfile(@CurrentUser() userId: string): Promise<GetMyResponse> {
@@ -86,13 +85,11 @@ export class UserController {
         description: '조회할 사용자 ID (UUID)',
         type: String,
     })
-    @ApiBearerAuth()
     @ApiResponse({
         status: 200,
         description: '조회 성공',
         type: GetUserResponse,
     })
-    @ApiResponse({ status: 401, description: '인증 실패' })
     @ApiResponse({ status: 404, description: '존재하지 않는 사용자' })
     @UseGuards(AuthGuard)
     @Get(':id')
@@ -105,10 +102,7 @@ export class UserController {
         description: '로그인한 사용자의 닉네임을 변경합니다.',
     })
     @ApiBody({ type: ChangeNicknameRequest })
-    @ApiBearerAuth()
     @ApiResponse({ status: 204, description: '닉네임 변경 성공 (No Content)' })
-    @ApiResponse({ status: 400, description: '잘못된 닉네임 형식' })
-    @ApiResponse({ status: 401, description: '인증 실패' })
     @UseGuards(AuthGuard)
     @HttpCode(HttpStatus.NO_CONTENT)
     @Patch('nickname')
@@ -125,10 +119,7 @@ export class UserController {
             '로그인한 사용자의 태그를 변경합니다. 태그는 고유해야 합니다.',
     })
     @ApiBody({ type: ChangeTagRequest })
-    @ApiBearerAuth()
     @ApiResponse({ status: 204, description: '태그 변경 성공 (No Content)' })
-    @ApiResponse({ status: 400, description: '잘못된 태그 형식' })
-    @ApiResponse({ status: 401, description: '인증 실패' })
     @UseGuards(AuthGuard)
     @HttpCode(HttpStatus.NO_CONTENT)
     @Patch('tag')

--- a/src/presentation/controller/users/users.controller.ts
+++ b/src/presentation/controller/users/users.controller.ts
@@ -21,6 +21,7 @@ import { CurrentUser } from 'src/common/decorator/current-user.decorator';
 import { AuthGuard } from 'src/common/guard/auth.guard';
 import { UserReader } from 'src/domain/components/users/user-reader';
 import { UserService } from 'src/domain/services/users/users.service';
+import { ChangeAvatarRequest } from 'src/presentation/dto/users/request/change-avatar.request';
 import { ChangeNicknameRequest } from 'src/presentation/dto/users/request/change-nickname.request';
 import { ChangeTagRequest } from 'src/presentation/dto/users/request/change-tag.request';
 import { SearchUsersRequest } from 'src/presentation/dto/users/request/search-users.request';
@@ -122,5 +123,19 @@ export class UserController {
         @CurrentUser() userId: string,
     ) {
         await this.userService.changeTag(userId, dto.tag);
+    }
+
+    @ApiOperation({
+        summary: '아바타 변경',
+        description: '로그인한 사용자의 아바타를 변경합니다.',
+    })
+    @ApiResponse({ status: 204, description: '아바타 변경 성공 (No Content)' })
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @Patch('avatar')
+    async changeAvatar(
+        @Body() dto: ChangeAvatarRequest,
+        @CurrentUser() userId: string,
+    ) {
+        await this.userService.changeAvatar(userId, dto.avatarKey);
     }
 }

--- a/src/presentation/dto/index.ts
+++ b/src/presentation/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './game';
 export * from './users';
+export * from './friends';

--- a/src/presentation/dto/package.json
+++ b/src/presentation/dto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mmorntype",
-    "version": "1.0.3",
+    "version": "1.0.5",
     "description": "mmorn dto type",
     "typings": "./types/index.d.ts",
     "files": [

--- a/src/presentation/dto/users/request/change-avatar.request.ts
+++ b/src/presentation/dto/users/request/change-avatar.request.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Length } from 'class-validator';
+
+export class ChangeAvatarRequest {
+    @ApiProperty({ example: 'blue_pawn', description: '아바타 키 값' })
+    @Length(2, 30)
+    readonly avatarKey: string;
+}

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -13,6 +13,7 @@ import { Varient } from 'src/presentation/dto/users/request/search-users.request
 import { SearchUserResponse } from 'src/presentation/dto/users/response/search-users.response';
 import { UserEntity } from 'src/domain/entities/user/user.entity';
 import { ResponseResult } from 'test/helper/types';
+import { ChangeAvatarRequest } from 'src/presentation/dto/users/request/change-avatar.request';
 
 describe('UserController (e2e)', () => {
     let app: INestApplication;
@@ -152,6 +153,30 @@ describe('UserController (e2e)', () => {
             const { status } = response;
 
             expect(status).toEqual(409);
+        });
+    });
+
+    describe('(PATCH) /users/avatar - 아바타 변경', () => {
+        it('아바타 변경 정상 동작', async () => {
+            const { accessToken } = await login(app);
+
+            const dto: ChangeAvatarRequest = {
+                avatarKey: 'red_pawn',
+            };
+
+            const response = await request(app.getHttpServer())
+                .patch('/users/avatar')
+                .send(dto)
+                .set('Authorization', accessToken);
+            const { status } = response;
+            const updatedUser = await prisma.user.findFirst({
+                where: {
+                    avatarKey: 'red_pawn',
+                },
+            });
+
+            expect(status).toEqual(204);
+            expect(updatedUser).not.toBeNull();
         });
     });
 


### PR DESCRIPTION
## 작업 내용
- 회원 아바타 변경 api 구현.
  - 정상 동작 e2e 작성.
- 공통으로 사용할 수 있는 swagger 데코레이터 controller에 부착.
  - 400, 401, bearer auth
- user controller에서 ApiBody 데코레이터 제거.
 - @Body를 사용하면 자동으로 인식해요.
- user controller에서 가드를 controller에서 부착
  - 인가가 필요하지 않은 기능이 없어요.

### 회원 정보 변경 관련 레이어 별 메서드 네이밍 수정
- presentation에 가까울 수록 현실에 가깝고, repo에 가까울 수록 데이터에 가까운 네이밍을 써야한다고 생각해요.
- 따라서 service에서 change, writer에서 update라는 네이밍을 쓰도록 수정했습니다.
- user repo의 update에서 id는 필수 값이기에, 매개변수로 따로 받고, 나머지 변경 데이터는 Partial<Entity>로 받도록 하고 repo 구현체 내부에서 변경 가능한 데이터만 추출해서 변경하도록 수정했어요.  ( 참고 ab3b97a74d52dd3badf1a8114497bf3d82ebcead )