### PR TITLE
친구 요청 검색 조건 추가 (거절, 삭제 필터링)

### DIFF
--- a/src/infrastructure/repositories/friend-prisma.repository.ts
+++ b/src/infrastructure/repositories/friend-prisma.repository.ts
@@ -37,6 +37,10 @@ export class FriendPrismaRepository implements FriendRepository {
                         deletedAt: null,
                     },
                 ],
+                status: {
+                    not: 'REJECTED',
+                },
+                deletedAt: null,
             },
         });
     }

--- a/test/e2e/friend.e2e-spec.ts
+++ b/test/e2e/friend.e2e-spec.ts
@@ -3,7 +3,7 @@ import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppModule } from 'src/app.module';
 import { PrismaService } from 'src/infrastructure/prisma/prisma.service';
-import { generateUserEntity } from 'test/helper/generators';
+import { generateFriendship, generateUserEntity } from 'test/helper/generators';
 import { login } from 'test/helper/login';
 import { SendFriendRequest } from 'src/presentation/dto/friends/request/send-friend.request';
 import { v4 } from 'uuid';
@@ -128,6 +128,43 @@ describe('FriendController (e2e)', () => {
                 .set('Authorization', currentUser.accessToken);
 
             expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+        });
+
+        it('거절 상태의 요청이 존재하는 경우에도 재요청이 가능하다', async () => {
+            const currentUser = await login(app);
+
+            const receivedUser = await prisma.user.create({
+                data: generateUserEntity(
+                    'receiver_conflict@email.com',
+                    'conflictNickname',
+                    'conflictTag',
+                ),
+            });
+
+            await prisma.friendRequest.create({
+                data: generateFriendship(currentUser.userId, receivedUser.id, {
+                    status: 'REJECTED',
+                }),
+            });
+
+            const dto: SendFriendRequest = {
+                targetUserId: receivedUser.id,
+            };
+
+            const response = await request(app.getHttpServer())
+                .post('/friends/requests')
+                .send(dto)
+                .set('Authorization', currentUser.accessToken);
+
+            const requestCount = await prisma.friendRequest.count({
+                where: {
+                    senderId: currentUser.userId,
+                    receiverId: receivedUser.id,
+                },
+            });
+
+            expect(response.status).toBe(HttpStatus.NO_CONTENT);
+            expect(requestCount).toBe(2);
         });
     });
 

--- a/test/helper/generators.ts
+++ b/test/helper/generators.ts
@@ -1,3 +1,4 @@
+import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
 import { IslandJoinEntity } from 'src/domain/entities/island-join/island-join.entity';
 import { IslandEntity } from 'src/domain/entities/islands/island.entity';
 import { UserEntity } from 'src/domain/entities/user/user.entity';
@@ -26,11 +27,11 @@ export const generateIsland = (
     const stdDate = new Date();
 
     return new IslandEntity(
-        partial?.id ?? v4(),
-        partial?.tag ?? 'dev',
-        partial?.createdAt ?? stdDate,
-        partial?.updatedAt ?? stdDate,
-        partial?.deletedAt ?? null,
+        partial?.id || v4(),
+        partial?.tag || 'dev',
+        partial?.createdAt || stdDate,
+        partial?.updatedAt || stdDate,
+        partial?.deletedAt || null,
     );
 };
 
@@ -40,10 +41,30 @@ export const generateIslandJoin = (
     const stdDate = new Date();
 
     return new IslandJoinEntity(
-        partial?.id ?? v4(),
-        partial?.islandId ?? v4(),
-        partial?.userId ?? v4(),
-        partial?.joinedAt ?? stdDate,
-        partial?.leftAt ?? null,
+        partial?.id || v4(),
+        partial?.islandId || v4(),
+        partial?.userId || v4(),
+        partial?.joinedAt || stdDate,
+        partial?.leftAt || null,
+    );
+};
+
+/**
+ * default status: 'PENDING'
+ */
+export const generateFriendship = (
+    senderId: string,
+    receiverId: string,
+    partial?: Partial<Omit<FriendEntity, 'senderId' | 'receiverId'>>,
+) => {
+    const stdDate = new Date();
+
+    return new FriendEntity(
+        partial?.id || v4(),
+        senderId,
+        receiverId,
+        partial?.status || 'PENDING',
+        partial?.createdAt || stdDate,
+        partial?.updatedAt || stdDate,
     );
 };


### PR DESCRIPTION
## 작업 내용
- 친구 요청 조회 시 거절, 삭제 된 요청은 조회되지 않도록 조건 추가.
  - 수정된 findRequestBetweenUsers 메서드를 사용하는 곳이 한 곳 뿐이라 나머지 코드는 그대로 두고 repo 메서드 조건을 수정했어요.
- 거절된 요청이 존재하는 경우에도 요청이 가능한 테스트 케이스 작성 (e2e)