### PR TITLE
회원 검색에 대한 변경사항 수정

### DIFF
--- a/src/domain/components/users/user-reader.ts
+++ b/src/domain/components/users/user-reader.ts
@@ -59,6 +59,7 @@ export class UserReader {
     }
 
     async search(
+        currentUserId: string,
         search: string,
         varient: Varient,
         limit: number,
@@ -70,6 +71,7 @@ export class UserReader {
 
         if (varient === Varient.NICKNAME) {
             return await this.userRepository.findStartWithNickname(
+                currentUserId,
                 search,
                 limit,
                 cursor,
@@ -77,6 +79,7 @@ export class UserReader {
         }
         if (varient === Varient.TAG) {
             return await this.userRepository.findStartWithTag(
+                currentUserId,
                 search,
                 limit,
                 cursor,
@@ -88,21 +91,5 @@ export class UserReader {
             HttpStatus.BAD_REQUEST,
             INVALID_INPUT_MESSAGE,
         );
-    }
-
-    async searchByNickname(
-        nickname: string,
-        limit: number,
-        cursor?: string,
-    ): Promise<PaginatedUsers> {
-        return await this.userRepository.findStartWithNickname(
-            nickname,
-            limit,
-            cursor,
-        );
-    }
-
-    async searchByTag(tag: string, limit: number, cursor?: string) {
-        return await this.userRepository.findStartWithTag(tag, limit, cursor);
     }
 }

--- a/src/domain/components/users/user-reader.ts
+++ b/src/domain/components/users/user-reader.ts
@@ -64,25 +64,30 @@ export class UserReader {
         limit: number,
         cursor?: string,
     ): Promise<PaginatedUsers> {
+        if (!search || search.trim() === '') {
+            return { data: [], nextCursor: null };
+        }
+
         if (varient === Varient.NICKNAME) {
             return await this.userRepository.findStartWithNickname(
                 search,
                 limit,
                 cursor,
             );
-        } else if (varient === Varient.TAG) {
+        }
+        if (varient === Varient.TAG) {
             return await this.userRepository.findStartWithTag(
                 search,
                 limit,
                 cursor,
             );
-        } else {
-            throw new DomainException(
-                DomainExceptionType.InvalidInput,
-                HttpStatus.BAD_REQUEST,
-                INVALID_INPUT_MESSAGE,
-            );
         }
+
+        throw new DomainException(
+            DomainExceptionType.InvalidInput,
+            HttpStatus.BAD_REQUEST,
+            INVALID_INPUT_MESSAGE,
+        );
     }
 
     async searchByNickname(

--- a/src/domain/exceptions/enum/domain-exception-type.ts
+++ b/src/domain/exceptions/enum/domain-exception-type.ts
@@ -3,6 +3,7 @@ export enum DomainExceptionType {
     ProviderConflict = 'ProviderConflict',
     UserEmailConflict = 'UserEmailConflict',
     UserNotFound = 'UserNotFound',
+    GetUserBadRequest = 'GetUserBadRequest',
     FriendRequestBadRequest = 'FriendRequestBadRequest',
     FriendRequestNotFound = 'FriendRequestNotFound',
     FriendRequestConflict = 'FriendRequestConflict',

--- a/src/domain/exceptions/message.ts
+++ b/src/domain/exceptions/message.ts
@@ -2,6 +2,8 @@ export const USER_NOT_REGISTERED_MESSAGE = '가입되지 않은 회원입니다.
 export const PROVIDER_CONFLICT = '다른 플랫폼으로 가입한 이력이 존재합니다.';
 export const USER_EMAIL_CONFLIC_MESSAGE = '이미 존재하는 이메일입니다.';
 export const USER_NOT_FOUND_MESSAGE = '존재하지 않는 회원입니다.';
+export const GET_USER_BAD_REQUEST_MESSAGE =
+    '자기 자신의 정보는 조회할 수 없습니다.';
 export const FRIEND_REQUEST_BAD_REQUEST_MESSAGE =
     '자기 자신에게 친구 요청을 보낼 수 없습니다.';
 export const FRIEND_REQUEST_NOT_FOUND_MESSAGE =

--- a/src/domain/interface/user.repository.ts
+++ b/src/domain/interface/user.repository.ts
@@ -7,11 +7,13 @@ export interface UserRepository {
     findOneByEmail(emial: string): Promise<UserInfo | null>;
     findOneByTag(tag: string): Promise<UserInfo | null>;
     findStartWithNickname(
+        currentUserId: string,
         nickname: string,
         limit: number,
         cursor?: string,
     ): Promise<PaginatedUsers>;
     findStartWithTag(
+        currentUserId: string,
         tag: string,
         limit: number,
         cursor?: string,

--- a/src/domain/services/users/users.service.ts
+++ b/src/domain/services/users/users.service.ts
@@ -1,15 +1,18 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
+import { FriendReader } from 'src/domain/components/friends/friend-reader';
 import { UserReader } from 'src/domain/components/users/user-reader';
 import { UserWriter } from 'src/domain/components/users/user-writer';
 import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
 import { DomainException } from 'src/domain/exceptions/exceptions';
 import { TAG_CONFLICT_MESSAGE } from 'src/domain/exceptions/message';
+import { GetUserResponse } from 'src/presentation/dto';
 
 @Injectable()
 export class UserService {
     constructor(
         private readonly userReader: UserReader,
         private readonly userWriter: UserWriter,
+        private readonly friendReader: FriendReader,
     ) {}
 
     async changeNickname(userId: string, nickname: string) {
@@ -40,5 +43,40 @@ export class UserService {
 
     async changeAvatar(userId: string, avatarKey: string) {
         await this.userWriter.updateAvatarKey(userId, avatarKey);
+    }
+
+    async getUserProfile(
+        currentUserId: string,
+        targetUserId: string,
+    ): Promise<GetUserResponse> {
+        const user = await this.userReader.readProfile(targetUserId);
+
+        if (currentUserId === targetUserId) {
+            return {
+                ...user,
+                friendStatus: null,
+            };
+        }
+
+        try {
+            const request = await this.friendReader.readRequestBetweenUsers(
+                currentUserId,
+                targetUserId,
+            );
+
+            if (request.status === 'ACCEPTED') {
+                return {
+                    ...user,
+                    friendStatus: 'ACCEPTED',
+                };
+            }
+
+            return { ...user, friendStatus: 'ACCEPTED' };
+        } catch (_) {
+            return {
+                ...user,
+                friendStatus: null,
+            };
+        }
     }
 }

--- a/src/domain/services/users/users.service.ts
+++ b/src/domain/services/users/users.service.ts
@@ -4,7 +4,10 @@ import { UserReader } from 'src/domain/components/users/user-reader';
 import { UserWriter } from 'src/domain/components/users/user-writer';
 import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
 import { DomainException } from 'src/domain/exceptions/exceptions';
-import { TAG_CONFLICT_MESSAGE } from 'src/domain/exceptions/message';
+import {
+    GET_USER_BAD_REQUEST_MESSAGE,
+    TAG_CONFLICT_MESSAGE,
+} from 'src/domain/exceptions/message';
 import { GetUserResponse } from 'src/presentation/dto';
 
 @Injectable()
@@ -52,10 +55,11 @@ export class UserService {
         const user = await this.userReader.readProfile(targetUserId);
 
         if (currentUserId === targetUserId) {
-            return {
-                ...user,
-                friendStatus: null,
-            };
+            throw new DomainException(
+                DomainExceptionType.GetUserBadRequest,
+                HttpStatus.BAD_REQUEST,
+                GET_USER_BAD_REQUEST_MESSAGE,
+            );
         }
 
         try {
@@ -64,14 +68,9 @@ export class UserService {
                 targetUserId,
             );
 
-            if (request.status === 'ACCEPTED') {
-                return {
-                    ...user,
-                    friendStatus: 'ACCEPTED',
-                };
-            }
-
-            return { ...user, friendStatus: 'ACCEPTED' };
+            return request.status === 'ACCEPTED'
+                ? { ...user, friendStatus: 'ACCEPTED' }
+                : { ...user, friendStatus: 'PENDING' };
         } catch (_) {
             return {
                 ...user,

--- a/src/infrastructure/repositories/user-prisma.repository.ts
+++ b/src/infrastructure/repositories/user-prisma.repository.ts
@@ -65,6 +65,7 @@ export class UserPrismaRepository implements UserRepository {
     }
 
     async findStartWithNickname(
+        currentUserId: string,
         nickname: string,
         limit: number,
         cursor?: string,
@@ -81,6 +82,9 @@ export class UserPrismaRepository implements UserRepository {
                 avatarKey: true,
             },
             where: {
+                id: {
+                    not: currentUserId,
+                },
                 nickname: {
                     startsWith: nickname,
                 },
@@ -101,6 +105,7 @@ export class UserPrismaRepository implements UserRepository {
     }
 
     async findStartWithTag(
+        currentUserId: string,
         tag: string,
         limit: number,
         cursor?: string,
@@ -116,6 +121,9 @@ export class UserPrismaRepository implements UserRepository {
                 avatarKey: true,
             },
             where: {
+                id: {
+                    not: currentUserId,
+                },
                 tag: {
                     startsWith: tag,
                 },

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UserController } from 'src/presentation/controller/users/users.controller';
 import { UserService } from 'src/domain/services/users/users.service';
 import { UserComponentModule } from 'src/modules/users/users-component.module';
+import { FriendsComponentModule } from '../friends/friends-component.module';
 
 @Module({
-    imports: [UserComponentModule],
+    imports: [UserComponentModule, FriendsComponentModule],
     controllers: [UserController],
     providers: [UserService],
     exports: [UserService],

--- a/src/presentation/controller/users/users.controller.ts
+++ b/src/presentation/controller/users/users.controller.ts
@@ -94,7 +94,10 @@ export class UserController {
     @ApiResponse({
         status: 200,
         description: '조회 성공',
-        type: GetUserResponse,
+    })
+    @ApiResponse({
+        status: 400,
+        description: '자신의 정보 조회시 BAD REQUEST 응답',
     })
     @ApiResponse({ status: 404, description: '존재하지 않는 사용자' })
     @Get(':id')

--- a/src/presentation/controller/users/users.controller.ts
+++ b/src/presentation/controller/users/users.controller.ts
@@ -98,8 +98,14 @@ export class UserController {
     })
     @ApiResponse({ status: 404, description: '존재하지 않는 사용자' })
     @Get(':id')
-    async getUser(@Param('id') userId: string): Promise<GetUserResponse> {
-        return await this.userReader.readProfile(userId);
+    async getUser(
+        @CurrentUser() currentUserId: string,
+        @Param('id') targetUserId: string,
+    ): Promise<GetUserResponse> {
+        return await this.userService.getUserProfile(
+            currentUserId,
+            targetUserId,
+        );
     }
 
     @ApiOperation({

--- a/src/presentation/controller/users/users.controller.ts
+++ b/src/presentation/controller/users/users.controller.ts
@@ -52,11 +52,18 @@ export class UserController {
     })
     @Get('search')
     async searchUser(
+        @CurrentUser() userId: string,
         @Query() query: SearchUsersRequest,
     ): Promise<SearchUserResponse> {
         const { search, varient, cursor, limit = 10 } = query;
 
-        return await this.userReader.search(search, varient, limit, cursor);
+        return await this.userReader.search(
+            userId,
+            search,
+            varient,
+            limit,
+            cursor,
+        );
     }
 
     @ApiOperation({

--- a/src/presentation/dto/shared.ts
+++ b/src/presentation/dto/shared.ts
@@ -1,2 +1,3 @@
 export type RoomType = 'dev' | 'design';
 export type Provider = 'GOOGLE' | 'KAKAO' | 'NAVER';
+export type FrinedStatus = 'ACCEPTED' | 'PENDING' | 'REJECTED';

--- a/src/presentation/dto/users/request/search-users.request.ts
+++ b/src/presentation/dto/users/request/search-users.request.ts
@@ -1,6 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import {
+    IsEnum,
+    IsInt,
+    IsOptional,
+    IsString,
+    Min,
+    MinLength,
+} from 'class-validator';
 
 export enum Varient {
     TAG = 'TAG',
@@ -13,6 +20,7 @@ export class SearchUsersRequest {
         description: '검색할 닉네임 또는 태그',
         type: String,
     })
+    @MinLength(2, { message: '검색어는 최소 2자 이상 입력해주세요' })
     @IsString()
     readonly search: string;
 

--- a/src/presentation/dto/users/response/get-user.response.ts
+++ b/src/presentation/dto/users/response/get-user.response.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Provider } from '../../shared';
 
 export class GetUserResponse {
@@ -25,4 +25,11 @@ export class GetUserResponse {
 
     @ApiProperty({ description: '사용자 아바타 키' })
     readonly avatarKey: string;
+
+    @ApiPropertyOptional({
+        description: '요청자와 친구 상태일 경우 ACCEPTED 아닐 경우 null',
+        nullable: true,
+        example: 'ACCEPTED',
+    })
+    readonly friendStatus?: string | null;
 }

--- a/src/presentation/dto/users/response/get-user.response.ts
+++ b/src/presentation/dto/users/response/get-user.response.ts
@@ -1,35 +1,38 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import { Provider } from '../../shared';
 
 export class GetUserResponse {
     @ApiProperty({
-        description: '사용자 ID(UUID V4)',
+        description: '타겟 사용자 ID(UUID V4)',
         example: '123e4567-e89b-12d3-a456-426614174000',
     })
     readonly id: string;
 
-    @ApiProperty({ description: '사용자 이메일', example: 'user@eamil.com' })
+    @ApiProperty({
+        description: '타겟 사용자의 이메일',
+        example: 'user@eamil.com',
+    })
     readonly email: string;
 
-    @ApiProperty({ description: '사용자 닉네임', example: 'nickname' })
+    @ApiProperty({ description: '타겟 사용자의 닉네임', example: 'nickname' })
     readonly nickname: string;
 
-    @ApiProperty({ description: '사용자 태그', example: 'tag' })
+    @ApiProperty({ description: '타겟 사용자의 태그', example: 'tag' })
     readonly tag: string;
 
     @ApiProperty({
-        description: '소셜 로그인 제공자',
+        description: '타겟 사용자의 소셜 로그인 제공자',
         enum: ['GOOGLE', 'KAKAO', 'NAVER'],
     })
     readonly provider: Provider;
 
-    @ApiProperty({ description: '사용자 아바타 키' })
+    @ApiProperty({ description: '타겟 사용자의 아바타 키' })
     readonly avatarKey: string;
 
-    @ApiPropertyOptional({
-        description: '요청자와 친구 상태일 경우 ACCEPTED 아닐 경우 null',
-        nullable: true,
+    @ApiProperty({
+        description:
+            '요청자와 타겟 유저가 친구 상태일 경우 ACCEPTED 아닐 경우 null',
         example: 'ACCEPTED',
     })
-    readonly friendStatus?: string | null;
+    readonly friendStatus: string | null;
 }

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -114,20 +114,15 @@ describe('UserController (e2e)', () => {
             expect(body).toHaveProperty('friendStatus', null);
         });
 
-        it('자신의 프로필 정보 조회 시 friendStatus가 null이어야 한다', async () => {
+        it('자신의 프로필 정보 조회 시 400 에러 코드 응답', async () => {
             const currentUser = await login(app);
-            const response = (await request(app.getHttpServer())
+            const response = await request(app.getHttpServer())
                 .get(`/users/${currentUser.userId}`)
-                .set(
-                    'Authorization',
-                    currentUser.accessToken,
-                )) as ResponseResult<GetUserResponse>;
+                .set('Authorization', currentUser.accessToken);
 
-            const { status, body } = response;
+            const { status } = response;
 
-            expect(status).toEqual(HttpStatus.OK);
-            expect(body).toHaveProperty('id', currentUser.userId);
-            expect(body).toHaveProperty('friendStatus', null);
+            expect(status).toEqual(HttpStatus.BAD_REQUEST);
         });
 
         it('유저 검색 유저ID 에러 동작', async () => {

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -1,6 +1,6 @@
 import * as request from 'supertest';
 
-import { INestApplication } from '@nestjs/common';
+import { HttpStatus, INestApplication } from '@nestjs/common';
 import { PrismaService } from 'src/infrastructure/prisma/prisma.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppModule } from 'src/app.module';
@@ -379,6 +379,19 @@ describe('UserController (e2e)', () => {
                 .query({ search: 'test', varient: Varient.NICKNAME, limit: 0 })
                 .set('Authorization', accessToken);
             expect(response.status).toEqual(400);
+        });
+        it('검색어가 최소 길이(2) 미만일 경우 400 에러를 반환한다 (빈 문자열)', async () => {
+            const { accessToken } = await login(app);
+
+            const response = await request(app.getHttpServer())
+                .get('/users/search')
+                .query({
+                    search: '',
+                    varient: Varient.NICKNAME,
+                })
+                .set('Authorization', accessToken);
+
+            expect(response.status).toEqual(HttpStatus.BAD_REQUEST);
         });
     });
 });


### PR DESCRIPTION
## 연관 이슈
#43 
## 작업 내용
- 회원 검색에 대한 벨리데이션을 추가했어요.
- 회원 검색어가 빈 값으로 요청 될경우 전체 데이터를 응답 값을로 반환하는 부분을 수정했어요.
- 회원 검색시, 현재 로그인된 사용자의 정보가 나오지 않게 수정했어요.
- 특정 유저의 정보를 조회시,  현재 로그인된 사용자와 친구 관계 상태 응답을 추가했어요.
- 변경 사항에 대한 e2e 테스트 케이스를 추가했어요.