### PR TITLE
Feat/player online

### DIFF
--- a/src/domain/interface/storages/game-storage.ts
+++ b/src/domain/interface/storages/game-storage.ts
@@ -1,4 +1,5 @@
-import { Player, Island, IslandTag } from 'src/domain/types/game.types';
+import { Player } from 'src/domain/models/game/player';
+import { Island, IslandTag } from 'src/domain/types/game.types';
 
 export interface GameStorage {
     getPlayer(playerId: string): Player | null;

--- a/src/domain/interface/storages/game-storage.ts
+++ b/src/domain/interface/storages/game-storage.ts
@@ -6,6 +6,7 @@ export interface GameStorage {
     getPlayerByClientId(clientId: string): Player | null;
     addPlayer(playerId: string, player: Player): void;
     deletePlayer(playerId: string): void;
+    getPlayersByIslandId(islandId: string): Player[];
 
     createIsland(islandId: string, island: Island): void;
     getIsland(islandId: string): Island | null;

--- a/src/domain/models/game/player.ts
+++ b/src/domain/models/game/player.ts
@@ -1,0 +1,65 @@
+export interface PlayerPrototype {
+    readonly id: string;
+    readonly clientId: string;
+    readonly nickname: string;
+    readonly tag: string;
+    readonly avatarKey: string;
+    readonly roomId: string;
+    readonly x: number;
+    readonly y: number;
+    readonly isFacingRight?: boolean;
+    readonly lastMoved?: number;
+    readonly lastActivity?: number;
+}
+
+export class Player {
+    constructor(
+        public readonly id: string,
+        public readonly clientId: string,
+        public roomId: string,
+        public nickname: string,
+        public tag: string,
+        public avatarKey: string,
+        public x: number,
+        public y: number,
+        public isFacingRight: boolean,
+        public lastMoved: number,
+        public lastActivity: number,
+    ) {}
+
+    update<K extends keyof Omit<Player, 'id' | 'clientId'>>(
+        key: K,
+        value: Player[K],
+    ) {
+        (this as any)[key] = value;
+        this.lastActivity = Date.now();
+    }
+
+    setPosition(x: number, y: number) {
+        this.x = x;
+        this.y = y;
+        this.updateLastActivity();
+    }
+
+    updateLastActivity() {
+        this.lastActivity = Date.now();
+    }
+
+    static create(proto: PlayerPrototype) {
+        const now = Date.now();
+
+        return new Player(
+            proto.id,
+            proto.clientId,
+            proto.roomId,
+            proto.nickname,
+            proto.tag,
+            proto.avatarKey,
+            proto.x,
+            proto.y,
+            proto.isFacingRight || true,
+            proto.lastMoved || now,
+            proto.lastActivity || now,
+        );
+    }
+}

--- a/src/domain/models/game/player.ts
+++ b/src/domain/models/game/player.ts
@@ -38,6 +38,8 @@ export class Player {
     setPosition(x: number, y: number) {
         this.x = x;
         this.y = y;
+
+        this.lastMoved = Date.now();
         this.updateLastActivity();
     }
 

--- a/src/domain/services/chat-messages/chat-message.service.ts
+++ b/src/domain/services/chat-messages/chat-message.service.ts
@@ -1,11 +1,26 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { ChatMessageWriter } from 'src/domain/components/chat-message/chat-message-writer';
 import { ChatMessageEntity } from 'src/domain/entities/chat-messages/chat-message.entity';
+import { GameStorage } from 'src/domain/interface/storages/game-storage';
 import { v4 } from 'uuid';
 
 @Injectable()
 export class ChatMessageService {
-    constructor(private readonly chatMessageWriter: ChatMessageWriter) {}
+    constructor(
+        @Inject(GameStorage)
+        private readonly gameStorage: GameStorage,
+        private readonly chatMessageWriter: ChatMessageWriter,
+    ) {}
+
+    async sendMessage(senderId: string, message: string) {
+        const player = this.gameStorage.getPlayer(senderId);
+        if (!player) throw new Error('없는 플레이어');
+
+        const { roomId } = player;
+        await this.create(senderId, roomId, message, 'island');
+
+        return player;
+    }
 
     async create(
         senderId: string,

--- a/src/domain/services/chat-messages/chat-message.service.ts
+++ b/src/domain/services/chat-messages/chat-message.service.ts
@@ -19,6 +19,8 @@ export class ChatMessageService {
         const { roomId } = player;
         await this.create(senderId, roomId, message, 'island');
 
+        player.updateLastActivity();
+
         return player;
     }
 

--- a/src/domain/services/game/game.service.ts
+++ b/src/domain/services/game/game.service.ts
@@ -225,6 +225,7 @@ export class GameService {
             .filter((player) => player !== null)
             .filter((player) => player.id !== attacker.id)
             .filter((player) => this.isInAttackBox(player, attackBox));
+        attacker.updateLastActivity();
 
         return {
             attacker,

--- a/src/domain/services/game/game.service.ts
+++ b/src/domain/services/game/game.service.ts
@@ -264,6 +264,19 @@ export class GameService {
         return distanceSquared < playerRadius * playerRadius;
     }
 
+    hearbeatFromIsland(
+        playerId: string,
+    ): { id: string; lastActivity: number }[] {
+        const player = this.gameStorage.getPlayer(playerId);
+        if (!player) throw new Error();
+
+        const players = this.gameStorage.getPlayersByIslandId(player.roomId);
+        return players.map((player) => ({
+            id: player.id,
+            lastActivity: player.lastActivity,
+        }));
+    }
+
     loggingStore(logger: Logger) {
         logger.debug('전체 회원', this.gameStorage.getPlayerStore());
         logger.debug('전체 방', this.gameStorage.getIslandStore());

--- a/src/domain/services/game/game.service.ts
+++ b/src/domain/services/game/game.service.ts
@@ -117,6 +117,23 @@ export class GameService {
         };
     }
 
+    async leftPlayer(playerId: string) {
+        const player = this.gameStorage.getPlayer(playerId);
+        if (!player) return;
+
+        const room = this.gameStorage.getIsland(player.roomId);
+        if (!room) return;
+
+        const { roomId } = player;
+
+        await this.islandJoinWriter.left(roomId, player.id);
+
+        this.gameStorage.deletePlayer(playerId);
+        room.players.delete(playerId);
+
+        return player;
+    }
+
     async leaveRoom(islandId: string, playerId: string) {
         const player = this.gameStorage.getPlayer(playerId);
         if (!player) return;

--- a/src/domain/services/game/game.service.ts
+++ b/src/domain/services/game/game.service.ts
@@ -195,10 +195,21 @@ export class GameService {
         return player;
     }
 
-    attack(attacker: Player) {
-        const island = this.gameStorage.getIsland(attacker.roomId);
-        if (!island || island.players.size === 0) return;
+    attack(attackerId: string) {
+        const attacker = this.gameStorage.getPlayer(attackerId);
+        if (!attacker) throw new Error('없는 회원');
 
+        const island = this.gameStorage.getIsland(attacker.roomId);
+        if (!island) throw new Error('없는 섬');
+
+        if (island.players.size === 0) {
+            return {
+                attacker,
+                attackedPlayers: [],
+            };
+        }
+
+        // 아바타 추가되면 avatarKey에 따라 분기
         const boxSize = ATTACK_BOX_SIZE.PAWN;
         const attackBox = {
             x: attacker.isFacingRight
@@ -209,13 +220,16 @@ export class GameService {
             height: boxSize.height,
         };
 
-        const attackedPlayer = Array.from(island.players)
+        const attackedPlayers = Array.from(island.players)
             .map((playerId) => this.getPlayer(playerId))
             .filter((player) => player !== null)
             .filter((player) => player.id !== attacker.id)
             .filter((player) => this.isInAttackBox(player, attackBox));
 
-        return attackedPlayer;
+        return {
+            attacker,
+            attackedPlayers,
+        };
     }
 
     isInAttackBox(

--- a/src/domain/services/game/game.service.ts
+++ b/src/domain/services/game/game.service.ts
@@ -13,7 +13,7 @@ import { UserReader } from 'src/domain/components/users/user-reader';
 import { Player } from 'src/domain/models/game/player';
 
 @Injectable()
-export class ZoneService {
+export class GameService {
     constructor(
         @Inject(GameStorage)
         private readonly gameStorage: GameStorage,

--- a/src/domain/services/users/users.service.ts
+++ b/src/domain/services/users/users.service.ts
@@ -67,10 +67,12 @@ export class UserService {
                 currentUserId,
                 targetUserId,
             );
+            const { status: friendStatus } = request;
 
-            return request.status === 'ACCEPTED'
-                ? { ...user, friendStatus: 'ACCEPTED' }
-                : { ...user, friendStatus: 'PENDING' };
+            return {
+                ...user,
+                friendStatus,
+            };
         } catch (_) {
             return {
                 ...user,

--- a/src/domain/types/game.types.ts
+++ b/src/domain/types/game.types.ts
@@ -2,19 +2,6 @@ export type IslandTag = 'dev' | 'design';
 
 export type SocketClientId = string;
 
-export interface Player {
-    id: string;
-    nickname: string;
-    tag: string;
-    avatarKey: string;
-    clientId: string;
-    roomId: string;
-    x: number;
-    y: number;
-    isFacingRight: boolean;
-    lastMoved: number;
-}
-
 export interface Island {
     id: string;
     players: Set<string>;

--- a/src/infrastructure/storages/memory-storage.ts
+++ b/src/infrastructure/storages/memory-storage.ts
@@ -1,10 +1,6 @@
 import { GameStorage } from 'src/domain/interface/storages/game-storage';
-import {
-    Player,
-    Island,
-    IslandTag,
-    SocketClientId,
-} from 'src/domain/types/game.types';
+import { Player } from 'src/domain/models/game/player';
+import { Island, IslandTag, SocketClientId } from 'src/domain/types/game.types';
 
 export class MemoryStorage implements GameStorage {
     private players = new Map<SocketClientId, Player>();

--- a/src/infrastructure/storages/memory-storage.ts
+++ b/src/infrastructure/storages/memory-storage.ts
@@ -29,6 +29,15 @@ export class MemoryStorage implements GameStorage {
         this.players.delete(playerId);
     }
 
+    getPlayersByIslandId(islandId: string): Player[] {
+        const island = this.islands.get(islandId);
+        if (!island) throw new Error('존재하지 않는 섬');
+
+        return Array.from(island.players)
+            .map((playerId) => this.players.get(playerId))
+            .filter((player) => !!player);
+    }
+
     createIsland(islandId: string, island: Island): void {
         this.islands.set(islandId, island);
     }

--- a/src/modules/chat-messages/chat-message.module.ts
+++ b/src/modules/chat-messages/chat-message.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ChatMessageService } from 'src/domain/services/chat-messages/chat-message.service';
 import { ChatMessageComponentModule } from 'src/modules/chat-messages/chat-message-component.module';
+import { GameStorageModule } from 'src/modules/game/game-storage.module';
 
 @Module({
-    imports: [ChatMessageComponentModule],
+    imports: [GameStorageModule, ChatMessageComponentModule],
     providers: [ChatMessageService],
     exports: [ChatMessageService],
 })

--- a/src/modules/friends/friends.module.ts
+++ b/src/modules/friends/friends.module.ts
@@ -3,9 +3,10 @@ import { FriendsComponentModule } from './friends-component.module';
 import { FriendsController } from 'src/presentation/controller/friends/friends.controller';
 import { FriendsService } from 'src/domain/services/friends/friends.service';
 import { UserComponentModule } from '../users/users-component.module';
+import { GameStorageModule } from 'src/modules/game/game-storage.module';
 
 @Module({
-    imports: [FriendsComponentModule, UserComponentModule],
+    imports: [FriendsComponentModule, UserComponentModule, GameStorageModule],
     controllers: [FriendsController],
     providers: [FriendsService],
 })

--- a/src/modules/game/game-storage.module.ts
+++ b/src/modules/game/game-storage.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { GameStorage } from 'src/domain/interface/storages/game-storage';
+import { MemoryStorage } from 'src/infrastructure/storages/memory-storage';
+
+@Module({
+    providers: [{ provide: GameStorage, useClass: MemoryStorage }],
+    exports: [{ provide: GameStorage, useClass: MemoryStorage }],
+})
+export class GameStorageModule {}

--- a/src/modules/game/game.module.ts
+++ b/src/modules/game/game.module.ts
@@ -3,6 +3,7 @@ import { GameStorage } from 'src/domain/interface/storages/game-storage';
 import { ZoneService } from 'src/domain/services/game/zone.service';
 import { MemoryStorage } from 'src/infrastructure/storages/memory-storage';
 import { ChatMessageModule } from 'src/modules/chat-messages/chat-message.module';
+import { GameStorageModule } from 'src/modules/game/game-storage.module';
 import { IslandJoinComponentModule } from 'src/modules/island-joins/island-join-component.module';
 import { IslandComponentModule } from 'src/modules/islands/island-component.module';
 import { UserComponentModule } from 'src/modules/users/users-component.module';
@@ -10,15 +11,12 @@ import { GameZoneGateway } from 'src/presentation/gateway/game-zone.gateway';
 
 @Module({
     imports: [
+        GameStorageModule,
         UserComponentModule,
         IslandComponentModule,
         IslandJoinComponentModule,
         ChatMessageModule,
     ],
-    providers: [
-        GameZoneGateway,
-        ZoneService,
-        { provide: GameStorage, useClass: MemoryStorage },
-    ],
+    providers: [GameZoneGateway, ZoneService],
 })
 export class GameModule {}

--- a/src/modules/game/game.module.ts
+++ b/src/modules/game/game.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { GameStorage } from 'src/domain/interface/storages/game-storage';
-import { ZoneService } from 'src/domain/services/game/zone.service';
+import { GameService } from 'src/domain/services/game/game.service';
 import { MemoryStorage } from 'src/infrastructure/storages/memory-storage';
 import { ChatMessageModule } from 'src/modules/chat-messages/chat-message.module';
 import { GameStorageModule } from 'src/modules/game/game-storage.module';
@@ -17,6 +17,6 @@ import { GameZoneGateway } from 'src/presentation/gateway/game-zone.gateway';
         IslandJoinComponentModule,
         ChatMessageModule,
     ],
-    providers: [GameZoneGateway, ZoneService],
+    providers: [GameZoneGateway, GameService],
 })
 export class GameModule {}

--- a/src/modules/game/game.module.ts
+++ b/src/modules/game/game.module.ts
@@ -7,7 +7,7 @@ import { GameStorageModule } from 'src/modules/game/game-storage.module';
 import { IslandJoinComponentModule } from 'src/modules/island-joins/island-join-component.module';
 import { IslandComponentModule } from 'src/modules/islands/island-component.module';
 import { UserComponentModule } from 'src/modules/users/users-component.module';
-import { GameZoneGateway } from 'src/presentation/gateway/game-zone.gateway';
+import { IslandGateway } from 'src/presentation/gateway/island.gateway';
 
 @Module({
     imports: [
@@ -17,6 +17,6 @@ import { GameZoneGateway } from 'src/presentation/gateway/game-zone.gateway';
         IslandJoinComponentModule,
         ChatMessageModule,
     ],
-    providers: [GameZoneGateway, GameService],
+    providers: [IslandGateway, GameService],
 })
 export class GameModule {}

--- a/src/presentation/controller/friends/friends.controller.ts
+++ b/src/presentation/controller/friends/friends.controller.ts
@@ -56,6 +56,7 @@ export class FriendsController {
     @ApiResponse({
         status: 200,
         description: '조회 성공. 상대방 사용자 정보가 user 필드에 포함됩니다.',
+        type: GetFriendRequestsResponse,
     })
     @Get('requests')
     async getFriendRequests(

--- a/src/presentation/controller/friends/friends.controller.ts
+++ b/src/presentation/controller/friends/friends.controller.ts
@@ -110,7 +110,11 @@ export class FriendsController {
     }
 
     @ApiOperation({ summary: '친구 목록 조회' })
-    @ApiResponse({ status: 200, description: '친구 목록 정상 조회' })
+    @ApiResponse({
+        status: 200,
+        description: '친구 목록 정상 조회',
+        type: GetFriendsResponse,
+    })
     @Get()
     async getFriends(
         @CurrentUser() userId: string,

--- a/src/presentation/dto/friends/response/get-friends.response.ts
+++ b/src/presentation/dto/friends/response/get-friends.response.ts
@@ -18,6 +18,9 @@ export class FriendUserInfo {
 
     @ApiProperty({ description: '친구가 된 시각 (요청 수락 시간)' })
     readonly becameFriendAt: Date;
+
+    @ApiProperty({ description: '접속 여부' })
+    readonly isOnline: boolean;
 }
 
 export class GetFriendsResponse {

--- a/src/presentation/dto/game/index.ts
+++ b/src/presentation/dto/game/index.ts
@@ -10,5 +10,6 @@ export * from './response/player-moved.response';
 export * from './response/attacked.response';
 export * from './response/receive-message';
 export * from './response/message-sent.response';
+export * from './response/island-heartbeat';
 
 export * from './socket/type';

--- a/src/presentation/dto/game/response/island-heartbeat.ts
+++ b/src/presentation/dto/game/response/island-heartbeat.ts
@@ -1,0 +1,4 @@
+export type IslandHeartbeatResponse = {
+    readonly id: string;
+    readonly lastActivity: number;
+}[];

--- a/src/presentation/dto/game/socket/type.ts
+++ b/src/presentation/dto/game/socket/type.ts
@@ -10,6 +10,7 @@ import { ReceiveMessage } from '../response/receive-message';
 import { MessageSent } from '../response/message-sent.response';
 import { PlayerJoinSuccessResponse } from '../response/player-join-success.response';
 import { AttackedResponse } from '../response/attacked.response';
+import { IslandHeartbeatResponse } from '../response/island-heartbeat';
 
 export interface ClientToServer {
     playerJoin: (data: PlayerJoinRequest) => void;
@@ -18,6 +19,7 @@ export interface ClientToServer {
     playerMoved: (data: PlayerMovedRequest) => void;
     attack: () => void;
     sendMessage: (data: SendMessageRequest) => void;
+    islandHearbeat: () => void;
 }
 
 export interface ServerToClient {
@@ -30,6 +32,7 @@ export interface ServerToClient {
     attacked: (data: AttackedResponse) => void;
     receiveMessage: (data: ReceiveMessage) => void;
     messageSent: (data: MessageSent) => void;
+    islandHearbeat: (data: IslandHeartbeatResponse) => void;
 }
 
 export type TypedSocket = Socket<ClientToServer, ServerToClient>;

--- a/src/presentation/dto/package.json
+++ b/src/presentation/dto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mmorntype",
-    "version": "1.0.5",
+    "version": "1.0.8",
     "description": "mmorn dto type",
     "typings": "./types/index.d.ts",
     "files": [

--- a/src/presentation/dto/package.json
+++ b/src/presentation/dto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mmorntype",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "mmorn dto type",
     "typings": "./types/index.d.ts",
     "files": [

--- a/src/presentation/gateway/game-zone.gateway.ts
+++ b/src/presentation/gateway/game-zone.gateway.ts
@@ -13,7 +13,7 @@ import {
 import { v4 } from 'uuid';
 import { CurrentUserFromSocket } from 'src/common/decorator/current-user.decorator';
 import { WsAuthGuard } from 'src/common/guard/ws-auth.guard';
-import { ZoneService } from 'src/domain/services/game/zone.service';
+import { GameService } from 'src/domain/services/game/game.service';
 import { UserReader } from 'src/domain/components/users/user-reader';
 import { PlayerJoinRequest } from 'src/presentation/dto/game/request/player-join.request';
 import {
@@ -40,7 +40,7 @@ export class GameZoneGateway
     private readonly logger = new Logger(GameZoneGateway.name);
 
     constructor(
-        private readonly zoneService: ZoneService,
+        private readonly zoneService: GameService,
         private readonly chatMessageService: ChatMessageService,
         private readonly userReader: UserReader,
     ) {}

--- a/src/presentation/gateway/game-zone.gateway.ts
+++ b/src/presentation/gateway/game-zone.gateway.ts
@@ -82,15 +82,13 @@ export class GameZoneGateway
         @ConnectedSocket() client: TypedSocket,
         @CurrentUserFromSocket() userId: string,
     ) {
-        const player = this.zoneService.getPlayer(userId);
-        if (!player) return;
+        const player = await this.zoneService.leftPlayer(userId);
+        if (player) {
+            client.leave(player.roomId);
+            client.to(player.roomId).emit('playerLeft', { id: player.id });
 
-        const { roomId } = player;
-        client.leave(player.roomId);
-        await this.zoneService.leaveRoom(player.roomId, userId);
-        this.logger.log(`Leave cilent: ${client.id}`);
-
-        client.to(roomId).emit('playerLeft', { id: player.id });
+            this.logger.log(`Leave cilent: ${client.id}`);
+        }
     }
 
     @SubscribeMessage('playerMoved')

--- a/src/presentation/gateway/game-zone.gateway.ts
+++ b/src/presentation/gateway/game-zone.gateway.ts
@@ -155,6 +155,16 @@ export class GameZoneGateway
         }
     }
 
+    @SubscribeMessage('islandHearbeat')
+    async handleHeartbeat(
+        @ConnectedSocket() client: TypedSocket,
+        @CurrentUserFromSocket() userId: string,
+    ) {
+        const heartbeats = this.gameService.hearbeatFromIsland(userId);
+
+        client.emit('islandHearbeat', heartbeats);
+    }
+
     // -----------------------------------------------------------
 
     afterInit() {

--- a/src/presentation/gateway/island.gateway.ts
+++ b/src/presentation/gateway/island.gateway.ts
@@ -31,13 +31,13 @@ import { ChatMessageService } from 'src/domain/services/chat-messages/chat-messa
         origin: true,
     },
 })
-export class GameZoneGateway
+export class IslandGateway
     implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
 {
     @WebSocketServer()
     private readonly wss: Namespace<ClientToServer, ServerToClient>;
 
-    private readonly logger = new Logger(GameZoneGateway.name);
+    private readonly logger = new Logger(IslandGateway.name);
 
     constructor(
         private readonly gameService: GameService,

--- a/src/presentation/gateway/island.gateway.ts
+++ b/src/presentation/gateway/island.gateway.ts
@@ -42,7 +42,6 @@ export class IslandGateway
     constructor(
         private readonly gameService: GameService,
         private readonly chatMessageService: ChatMessageService,
-        private readonly userReader: UserReader,
     ) {}
 
     @SubscribeMessage('playerJoin')

--- a/test/e2e/friend.e2e-spec.ts
+++ b/test/e2e/friend.e2e-spec.ts
@@ -651,6 +651,7 @@ describe('FriendController (e2e)', () => {
                     avatarKey: friendUser.avatarKey,
                     friendshipId: friendship.id,
                     becameFriendAt: friendship.updatedAt.toISOString(),
+                    isOnline: false,
                 };
             });
 
@@ -698,6 +699,7 @@ describe('FriendController (e2e)', () => {
                         avatarKey: friendUser.avatarKey,
                         friendshipId: friendship.id,
                         becameFriendAt: friendship.updatedAt.toISOString(),
+                        isOnline: false,
                     };
                 });
 
@@ -747,6 +749,7 @@ describe('FriendController (e2e)', () => {
                         avatarKey: friendUser.avatarKey,
                         friendshipId: friendship.id,
                         becameFriendAt: friendship.updatedAt.toISOString(),
+                        isOnline: false,
                     };
                 });
 


### PR DESCRIPTION
## 작업 내용
- 회원 온라인 여부 기능 구현 (친구 조회, island에서의 참여자 목록)
  - 친구 목록 조회에 isOnline 속성 추가.
  - island gateway에서 최근 활동을 감지하는 heartbeat 메서드 추가.
- gateway에 있던 로직 game service로 이동.
- storage에 저장하는 player 타입을 interface 타입 객체에서, class 인스턴스로 변경
  - 자체 데이터 수정 및 상태 업데이트를 위함.
- 친구 목록 조회에 누락된 응답 스웨거 추가.