### PR TITLE
회원 소개 추가 및 수정 기능 구현

### DIFF
--- a/prisma/migrations/20250505154357_add_description_to_user/migration.sql
+++ b/prisma/migrations/20250505154357_add_description_to_user/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `userId` on the `island` table. All the data in the column will be lost.
+  - You are about to drop the `Tag` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "island_userId_idx";
+
+-- AlterTable
+ALTER TABLE "island" DROP COLUMN "userId";
+
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "description" VARCHAR;
+
+-- DropTable
+DROP TABLE "Tag";
+
+-- CreateTable
+CREATE TABLE "tag" (
+    "id" UUID NOT NULL,
+    "name" VARCHAR(50) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "island_ownerId_idx" ON "island"("ownerId");

--- a/prisma/migrations/20250505165051_change_description_to_bio/migration.sql
+++ b/prisma/migrations/20250505165051_change_description_to_bio/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `description` on the `user` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "user" DROP COLUMN "description",
+ADD COLUMN     "bio" VARCHAR;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,17 +27,17 @@ enum OAuthProvider {
 }
 
 model User {
-  id          String        @id @db.Uuid
-  email       String        @db.VarChar(255)
-  provider    OAuthProvider
-  nickname    String
-  tag         String
-  description String?       @db.VarChar
-  avatarKey   String
-  gold        Int           @default(0)
-  createdAt   DateTime      @map("created_at")
-  updatedAt   DateTime      @map("updated_at")
-  deletedAt   DateTime?     @map("deleted_at")
+  id        String        @id @db.Uuid
+  email     String        @db.VarChar(255)
+  provider  OAuthProvider
+  nickname  String
+  tag       String
+  bio       String?       @db.VarChar
+  avatarKey String
+  gold      Int           @default(0)
+  createdAt DateTime      @map("created_at")
+  updatedAt DateTime      @map("updated_at")
+  deletedAt DateTime?     @map("deleted_at")
 
   islandJoins            IslandJoin[]
   chatMessages           ChatMessage[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,16 +27,17 @@ enum OAuthProvider {
 }
 
 model User {
-  id        String        @id @db.Uuid
-  email     String        @db.VarChar(255)
-  provider  OAuthProvider
-  nickname  String
-  tag       String
-  avatarKey String
-  gold      Int           @default(0)
-  createdAt DateTime      @map("created_at")
-  updatedAt DateTime      @map("updated_at")
-  deletedAt DateTime?     @map("deleted_at")
+  id          String        @id @db.Uuid
+  email       String        @db.VarChar(255)
+  provider    OAuthProvider
+  nickname    String
+  tag         String
+  description String?       @db.VarChar
+  avatarKey   String
+  gold        Int           @default(0)
+  createdAt   DateTime      @map("created_at")
+  updatedAt   DateTime      @map("updated_at")
+  deletedAt   DateTime?     @map("deleted_at")
 
   islandJoins            IslandJoin[]
   chatMessages           ChatMessage[]

--- a/src/domain/components/users/user-writer.ts
+++ b/src/domain/components/users/user-writer.ts
@@ -28,4 +28,8 @@ export class UserWriter {
     async updateGoldBalance(id: string, gold: number) {
         await this.userRepository.update(id, { gold });
     }
+
+    async updateBio(id: string, bio: string | null) {
+        await this.userRepository.update(id, { bio });
+    }
 }

--- a/src/domain/entities/user/user.entity.ts
+++ b/src/domain/entities/user/user.entity.ts
@@ -12,6 +12,7 @@ export class UserEntity {
         readonly createdAt: Date,
         readonly updatedAt: Date,
         readonly deletedAt: Date | null = null,
+        readonly description?: string,
         readonly gold = 0,
     ) {}
 
@@ -30,6 +31,8 @@ export class UserEntity {
             input.avatarKey,
             stdDate,
             updatedAt ? updatedAt : stdDate,
+            null,
+            input.description,
         );
     }
 }

--- a/src/domain/entities/user/user.entity.ts
+++ b/src/domain/entities/user/user.entity.ts
@@ -12,7 +12,7 @@ export class UserEntity {
         readonly createdAt: Date,
         readonly updatedAt: Date,
         readonly deletedAt: Date | null = null,
-        readonly description?: string,
+        readonly bio?: string | null,
         readonly gold = 0,
     ) {}
 
@@ -32,7 +32,7 @@ export class UserEntity {
             stdDate,
             updatedAt ? updatedAt : stdDate,
             null,
-            input.description,
+            input.bio,
         );
     }
 }

--- a/src/domain/services/friends/friends.service.ts
+++ b/src/domain/services/friends/friends.service.ts
@@ -129,7 +129,7 @@ export class FriendsService {
         await this.friendWriter.deleteFriendship(friendshipId);
     }
 
-    async checkFriendship(
+    async getFriendshipStatus(
         userId: string,
         targeytUserId: string,
     ): Promise<FriendRequestStatus> {

--- a/src/domain/services/users/users.service.ts
+++ b/src/domain/services/users/users.service.ts
@@ -48,6 +48,10 @@ export class UserService {
         await this.userWriter.updateAvatarKey(userId, avatarKey);
     }
 
+    async changeBio(userId: string, bio: string | null) {
+        await this.userWriter.updateBio(userId, bio);
+    }
+
     async getUserProfile(
         currentUserId: string,
         targetUserId: string,

--- a/src/domain/services/users/users.service.ts
+++ b/src/domain/services/users/users.service.ts
@@ -4,11 +4,7 @@ import { UserReader } from 'src/domain/components/users/user-reader';
 import { UserWriter } from 'src/domain/components/users/user-writer';
 import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
 import { DomainException } from 'src/domain/exceptions/exceptions';
-import {
-    GET_USER_BAD_REQUEST_MESSAGE,
-    TAG_CONFLICT_MESSAGE,
-} from 'src/domain/exceptions/message';
-import { GetUserResponse } from 'src/presentation/dto';
+import { TAG_CONFLICT_MESSAGE } from 'src/domain/exceptions/message';
 
 @Injectable()
 export class UserService {
@@ -50,38 +46,5 @@ export class UserService {
 
     async changeBio(userId: string, bio: string | null) {
         await this.userWriter.updateBio(userId, bio);
-    }
-
-    async getUserProfile(
-        currentUserId: string,
-        targetUserId: string,
-    ): Promise<GetUserResponse> {
-        const user = await this.userReader.readProfile(targetUserId);
-
-        if (currentUserId === targetUserId) {
-            throw new DomainException(
-                DomainExceptionType.GET_USER_BAD_REQUEST,
-                HttpStatus.BAD_REQUEST,
-                GET_USER_BAD_REQUEST_MESSAGE,
-            );
-        }
-
-        try {
-            const request = await this.friendReader.readRequestBetweenUsers(
-                currentUserId,
-                targetUserId,
-            );
-            const { status: friendStatus } = request;
-
-            return {
-                ...user,
-                friendStatus,
-            };
-        } catch (_) {
-            return {
-                ...user,
-                friendStatus: null,
-            };
-        }
     }
 }

--- a/src/domain/types/uesr.types.ts
+++ b/src/domain/types/uesr.types.ts
@@ -10,6 +10,7 @@ export interface UserInfo {
     readonly tag: string;
     readonly provider: Provider;
     readonly avatarKey: string;
+    readonly bio: string | null;
 }
 
 export interface UserPrototype {

--- a/src/domain/types/uesr.types.ts
+++ b/src/domain/types/uesr.types.ts
@@ -18,7 +18,7 @@ export interface UserPrototype {
     readonly tag: string;
     readonly provider: Provider;
     readonly avatarKey: string;
-    readonly description?: string;
+    readonly bio?: string;
 }
 
 export interface PaginatedUsers {

--- a/src/domain/types/uesr.types.ts
+++ b/src/domain/types/uesr.types.ts
@@ -18,6 +18,7 @@ export interface UserPrototype {
     readonly tag: string;
     readonly provider: Provider;
     readonly avatarKey: string;
+    readonly description?: string;
 }
 
 export interface PaginatedUsers {

--- a/src/infrastructure/repositories/user-prisma.repository.ts
+++ b/src/infrastructure/repositories/user-prisma.repository.ts
@@ -23,6 +23,7 @@ export class UserPrismaRepository implements UserRepository {
                 tag: true,
                 provider: true,
                 avatarKey: true,
+                bio: true,
             },
             where: {
                 id: searchUserId,
@@ -39,6 +40,7 @@ export class UserPrismaRepository implements UserRepository {
                 tag: true,
                 provider: true,
                 avatarKey: true,
+                bio: true,
             },
             where: {
                 email: email,
@@ -56,6 +58,7 @@ export class UserPrismaRepository implements UserRepository {
                 tag: true,
                 provider: true,
                 avatarKey: true,
+                bio: true,
             },
             where: {
                 tag: tag,
@@ -80,6 +83,7 @@ export class UserPrismaRepository implements UserRepository {
                 tag: true,
                 provider: true,
                 avatarKey: true,
+                bio: true,
             },
             where: {
                 id: {
@@ -119,6 +123,7 @@ export class UserPrismaRepository implements UserRepository {
                 tag: true,
                 provider: true,
                 avatarKey: true,
+                bio: true,
             },
             where: {
                 id: {

--- a/src/infrastructure/repositories/user-prisma.repository.ts
+++ b/src/infrastructure/repositories/user-prisma.repository.ts
@@ -154,7 +154,7 @@ export class UserPrismaRepository implements UserRepository {
     }
 
     async update(id: string, data: Partial<UserEntity>): Promise<void> {
-        const { nickname, tag, avatarKey, gold } = data;
+        const { nickname, tag, avatarKey, gold, bio } = data;
 
         await this.prisma.user.update({
             data: {
@@ -162,6 +162,7 @@ export class UserPrismaRepository implements UserRepository {
                 tag,
                 avatarKey,
                 gold,
+                bio,
             },
             where: {
                 id,

--- a/src/modules/friends/friends.module.ts
+++ b/src/modules/friends/friends.module.ts
@@ -9,5 +9,6 @@ import { GameStorageModule } from 'src/modules/game/game-storage.module';
     imports: [FriendsComponentModule, UserComponentModule, GameStorageModule],
     controllers: [FriendsController],
     providers: [FriendsService],
+    exports: [FriendsService],
 })
 export class FriendsModule {}

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -3,9 +3,10 @@ import { UserController } from 'src/presentation/controller/users/users.controll
 import { UserService } from 'src/domain/services/users/users.service';
 import { UserComponentModule } from 'src/modules/users/users-component.module';
 import { FriendsComponentModule } from '../friends/friends-component.module';
+import { FriendsModule } from 'src/modules/friends/friends.module';
 
 @Module({
-    imports: [UserComponentModule, FriendsComponentModule],
+    imports: [UserComponentModule, FriendsComponentModule, FriendsModule],
     controllers: [UserController],
     providers: [UserService],
     exports: [UserService],

--- a/src/presentation/controller/friends/friends.controller.ts
+++ b/src/presentation/controller/friends/friends.controller.ts
@@ -141,7 +141,7 @@ export class FriendsController {
         @Query('targetId', ParseUUIDPipe) targetUserId: string,
         @CurrentUser() userId: string,
     ): Promise<CheckFriendshipResponse> {
-        const status = await this.friendsService.checkFriendship(
+        const status = await this.friendsService.getFriendshipStatus(
             userId,
             targetUserId,
         );

--- a/src/presentation/controller/users/users.controller.ts
+++ b/src/presentation/controller/users/users.controller.ts
@@ -19,6 +19,7 @@ import {
 import { CurrentUser } from 'src/common/decorator/current-user.decorator';
 import { AuthGuard } from 'src/common/guard/auth.guard';
 import { UserReader } from 'src/domain/components/users/user-reader';
+import { FriendsService } from 'src/domain/services/friends/friends.service';
 import { UserService } from 'src/domain/services/users/users.service';
 import { ChangeAvatarRequest } from 'src/presentation/dto/users/request/change-avatar.request';
 import { ChangeBioRequest } from 'src/presentation/dto/users/request/change-bio.request';
@@ -40,6 +41,7 @@ export class UserController {
     constructor(
         private readonly userService: UserService,
         private readonly userReader: UserReader,
+        private readonly friendService: FriendsService,
     ) {}
 
     @ApiOperation({
@@ -132,10 +134,16 @@ export class UserController {
         @CurrentUser() currentUserId: string,
         @Param('id') targetUserId: string,
     ): Promise<GetUserResponse> {
-        return await this.userService.getUserProfile(
+        const user = await this.userReader.readProfile(targetUserId);
+        const friendStatus = await this.friendService.getFriendshipStatus(
             currentUserId,
             targetUserId,
         );
+
+        return {
+            ...user,
+            friendStatus,
+        };
     }
 
     @ApiOperation({

--- a/src/presentation/controller/users/users.controller.ts
+++ b/src/presentation/controller/users/users.controller.ts
@@ -21,6 +21,7 @@ import { AuthGuard } from 'src/common/guard/auth.guard';
 import { UserReader } from 'src/domain/components/users/user-reader';
 import { UserService } from 'src/domain/services/users/users.service';
 import { ChangeAvatarRequest } from 'src/presentation/dto/users/request/change-avatar.request';
+import { ChangeBioRequest } from 'src/presentation/dto/users/request/change-bio.request';
 import { ChangeNicknameRequest } from 'src/presentation/dto/users/request/change-nickname.request';
 import { ChangeTagRequest } from 'src/presentation/dto/users/request/change-tag.request';
 import { SearchUsersRequest } from 'src/presentation/dto/users/request/search-users.request';
@@ -178,5 +179,19 @@ export class UserController {
         @CurrentUser() userId: string,
     ) {
         await this.userService.changeAvatar(userId, dto.avatarKey);
+    }
+
+    @ApiOperation({
+        summary: '설명 변경',
+        description: '로그인한 사용자의 설명을 변경합니다.',
+    })
+    @ApiResponse({ status: 204, description: '소개 변경 성공 (No Content)' })
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @Patch('bio')
+    async changeBio(
+        @Body() dto: ChangeBioRequest,
+        @CurrentUser() userId: string,
+    ) {
+        await this.userService.changeBio(userId, dto.bio);
     }
 }

--- a/src/presentation/dto/users/index.ts
+++ b/src/presentation/dto/users/index.ts
@@ -1,5 +1,6 @@
 export * from './request/change-nickname.request';
 export * from './request/change-tag.request';
+export * from './request/change-bio.request';
 export * from './request/search-users.request';
 
 export * from './response/get-me.response';

--- a/src/presentation/dto/users/request/change-bio.request.ts
+++ b/src/presentation/dto/users/request/change-bio.request.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Length, ValidateIf } from 'class-validator';
+
+export class ChangeBioRequest {
+    @ApiProperty({
+        example: '자기소개입니다.',
+        description: '자기소개 텍스트 (최대 30자)',
+        nullable: true,
+    })
+    @ValidateIf((v) => v !== null)
+    @Length(1, 300)
+    readonly bio: string | null;
+}

--- a/src/presentation/dto/users/request/change-bio.request.ts
+++ b/src/presentation/dto/users/request/change-bio.request.ts
@@ -3,11 +3,11 @@ import { Length, ValidateIf } from 'class-validator';
 
 export class ChangeBioRequest {
     @ApiProperty({
-        example: '자기소개입니다.',
-        description: '자기소개 텍스트 (최대 30자)',
+        example: '저는 접니다.',
+        description: '자기소개 텍스트 (최대 300자), null이면 없애기',
         nullable: true,
     })
-    @ValidateIf((v) => v !== null)
+    @ValidateIf((v: ChangeBioRequest) => v.bio !== null)
     @Length(1, 300)
     readonly bio: string | null;
 }

--- a/src/presentation/dto/users/response/get-user.response.ts
+++ b/src/presentation/dto/users/response/get-user.response.ts
@@ -30,6 +30,9 @@ export class GetUserResponse {
     @ApiProperty({ description: '타겟 사용자의 아바타 키' })
     readonly avatarKey: string;
 
+    @ApiProperty({ example: '나는 나다' })
+    readonly bio: string | null;
+
     @ApiProperty({
         description:
             '요청자와 타겟 유저가 친구 상태일 경우 ACCEPTED 아닐 경우 null',

--- a/src/presentation/dto/users/response/get-user.response.ts
+++ b/src/presentation/dto/users/response/get-user.response.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Provider } from '../../shared';
+import { FriendRequestStatus } from '../../../../domain/types/friend.types';
 
 export class GetUserResponse {
     @ApiProperty({
@@ -34,5 +35,5 @@ export class GetUserResponse {
             '요청자와 타겟 유저가 친구 상태일 경우 ACCEPTED 아닐 경우 null',
         example: 'ACCEPTED',
     })
-    readonly friendStatus: string | null;
+    readonly friendStatus: FriendRequestStatus;
 }

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -65,6 +65,7 @@ describe('UserController (e2e)', () => {
                 nickname: user.nickname,
                 provider: user.provider,
                 tag: user.tag,
+                bio: user.bio!,
                 friendStatus: 'NONE',
             };
 
@@ -96,6 +97,7 @@ describe('UserController (e2e)', () => {
                 nickname: user.nickname,
                 provider: user.provider,
                 tag: user.tag,
+                bio: user.bio!,
                 friendStatus: 'ACCEPTED',
             };
 
@@ -128,6 +130,7 @@ describe('UserController (e2e)', () => {
                 nickname: user.nickname,
                 provider: user.provider,
                 tag: user.tag,
+                bio: user.bio!,
                 friendStatus: 'SENT',
             };
 
@@ -160,6 +163,7 @@ describe('UserController (e2e)', () => {
                 nickname: user.nickname,
                 provider: user.provider,
                 tag: user.tag,
+                bio: user.bio!,
                 friendStatus: 'RECEIVED',
             };
 

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -8,7 +8,11 @@ import { AppModule } from 'src/app.module';
 import { login } from 'test/helper/login';
 import { ChangeNicknameRequest } from 'src/presentation/dto/users/request/change-nickname.request';
 import { ChangeTagRequest } from 'src/presentation/dto/users/request/change-tag.request';
-import { generateFriendship, generateUserEntity } from 'test/helper/generators';
+import {
+    generateFriendship,
+    generateUserEntity,
+    generateUserEntityV2,
+} from 'test/helper/generators';
 import { v4 } from 'uuid';
 import { SearchUserResponse } from 'src/presentation/dto/users/response/search-users.response';
 import { UserEntity } from 'src/domain/entities/user/user.entity';
@@ -45,43 +49,58 @@ describe('UserController (e2e)', () => {
     });
 
     describe('(GET) /users/:id', () => {
+        const user = generateUserEntityV2();
+
+        beforeEach(async () => {
+            await prisma.user.create({ data: user });
+        });
+
         it('유저 정보 조회 정상 동작', async () => {
             const { accessToken } = await login(app);
 
-            const user = await prisma.user.create({
-                data: generateUserEntity('test@email.com', 'test', '11111'),
-            });
+            const expected: GetUserResponse = {
+                id: user.id,
+                avatarKey: user.avatarKey,
+                email: user.email,
+                nickname: user.nickname,
+                provider: user.provider,
+                tag: user.tag,
+                friendStatus: 'NONE',
+            };
 
-            const response = await request(app.getHttpServer())
+            const response = (await request(app.getHttpServer())
                 .get(`/users/${user.id}`)
-                .set('Authorization', accessToken);
-
-            const { status } = response;
+                .set(
+                    'Authorization',
+                    accessToken,
+                )) as ResponseResult<GetUserResponse>;
+            const { status, body } = response;
 
             expect(status).toEqual(200);
-            expect(response.body).toHaveProperty('email', user.email);
-            expect(response.body).toHaveProperty('nickname', user.nickname);
-            expect(response.body).toHaveProperty('tag', user.tag);
+            expect(body).toEqual(expected);
         });
 
         it('친구 관계인 유저 정보 조회 시 friendStatus가 "ACCEPTED"여야 한다', async () => {
             const currentUser = await login(app);
-            const targetUser = await prisma.user.create({
-                data: generateUserEntity(
-                    'target@email.com',
-                    'targetUser',
-                    'tagTarget',
-                ),
-            });
 
             await prisma.friendRequest.create({
-                data: generateFriendship(currentUser.userId, targetUser.id, {
+                data: generateFriendship(currentUser.userId, user.id, {
                     status: FriendRequestStatus.ACCEPTED,
                 }),
             });
 
+            const expected: GetUserResponse = {
+                id: user.id,
+                avatarKey: user.avatarKey,
+                email: user.email,
+                nickname: user.nickname,
+                provider: user.provider,
+                tag: user.tag,
+                friendStatus: 'ACCEPTED',
+            };
+
             const response = (await request(app.getHttpServer())
-                .get(`/users/${targetUser.id}`)
+                .get(`/users/${user.id}`)
                 .set(
                     'Authorization',
                     currentUser.accessToken,
@@ -90,22 +109,30 @@ describe('UserController (e2e)', () => {
             const { status, body } = response;
 
             expect(status).toEqual(HttpStatus.OK);
-            expect(body).toHaveProperty('id', targetUser.id);
-            expect(body).toHaveProperty('friendStatus', 'ACCEPTED');
+            expect(body).toEqual(expected);
         });
 
-        it('친구 관계가 아닌 유저 정보 조회 시 friendStatus가 null이어야 한다', async () => {
+        it('내가 요청을 보낸 유저 정보 조회 시 friendStatus가 "SENT"여야 한다', async () => {
             const currentUser = await login(app);
-            const nonFriendUser = await prisma.user.create({
-                data: generateUserEntity(
-                    'nonfriend@email.com',
-                    'nonFriend',
-                    'tagNonFriend',
-                ),
+
+            await prisma.friendRequest.create({
+                data: generateFriendship(currentUser.userId, user.id, {
+                    status: FriendRequestStatus.PENDING,
+                }),
             });
 
+            const expected: GetUserResponse = {
+                id: user.id,
+                avatarKey: user.avatarKey,
+                email: user.email,
+                nickname: user.nickname,
+                provider: user.provider,
+                tag: user.tag,
+                friendStatus: 'SENT',
+            };
+
             const response = (await request(app.getHttpServer())
-                .get(`/users/${nonFriendUser.id}`)
+                .get(`/users/${user.id}`)
                 .set(
                     'Authorization',
                     currentUser.accessToken,
@@ -114,19 +141,39 @@ describe('UserController (e2e)', () => {
             const { status, body } = response;
 
             expect(status).toEqual(HttpStatus.OK);
-            expect(body).toHaveProperty('id', nonFriendUser.id);
-            expect(body).toHaveProperty('friendStatus', null);
+            expect(body).toEqual(expected);
         });
 
-        it('자신의 프로필 정보 조회 시 400 에러 코드 응답', async () => {
+        it('내가 요청을 보낸 유저 정보 조회 시 friendStatus가 "SENT"여야 한다', async () => {
             const currentUser = await login(app);
-            const response = await request(app.getHttpServer())
-                .get(`/users/${currentUser.userId}`)
-                .set('Authorization', currentUser.accessToken);
 
-            const { status } = response;
+            await prisma.friendRequest.create({
+                data: generateFriendship(user.id, currentUser.userId, {
+                    status: FriendRequestStatus.PENDING,
+                }),
+            });
 
-            expect(status).toEqual(HttpStatus.BAD_REQUEST);
+            const expected: GetUserResponse = {
+                id: user.id,
+                avatarKey: user.avatarKey,
+                email: user.email,
+                nickname: user.nickname,
+                provider: user.provider,
+                tag: user.tag,
+                friendStatus: 'RECEIVED',
+            };
+
+            const response = (await request(app.getHttpServer())
+                .get(`/users/${user.id}`)
+                .set(
+                    'Authorization',
+                    currentUser.accessToken,
+                )) as ResponseResult<GetUserResponse>;
+
+            const { status, body } = response;
+
+            expect(status).toEqual(HttpStatus.OK);
+            expect(body).toEqual(expected);
         });
 
         it('유저 검색 유저ID 에러 동작', async () => {

--- a/test/helper/generators.ts
+++ b/test/helper/generators.ts
@@ -40,6 +40,7 @@ export const generateUserEntityV2 = (partial?: Partial<UserEntity>) => {
         partial?.createdAt || stdDate,
         partial?.updatedAt || stdDate,
         partial?.deletedAt || null,
+        partial?.bio,
         partial?.gold,
     );
 };

--- a/test/helper/generators.ts
+++ b/test/helper/generators.ts
@@ -40,7 +40,7 @@ export const generateUserEntityV2 = (partial?: Partial<UserEntity>) => {
         partial?.createdAt || stdDate,
         partial?.updatedAt || stdDate,
         partial?.deletedAt || null,
-        partial?.bio,
+        partial?.bio || '난 나다',
         partial?.gold,
     );
 };

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mmorntype",
-    "version": "1.0.40",
+    "version": "1.0.42",
     "description": "mmorn dto type",
     "typings": "./dist/types/index.d.ts",
     "files": [


### PR DESCRIPTION
## 작업 내용
### 회원 관련
- `user` 테이블에 `bio` (소개) 컬럼 추가
- 소개 변경 api 구현.
- 회원 프로필 조회 리팩토링 211d4445f51172e5ff8fd3dc1bb1ef66e4ee166c
  - `usreService`에서 상세 조회 메서드 제거.
  - `userController`에서 `friendService`의 친구 상태와 `userReader`에서의 `profile` 조회 정보를 조합하여 응답.
- 모든 회원 조회 응답에 타입에 bio 추가.
  - repo에서 모든 회원 단 건 검색이 같은 UserInfo 타입을 쓰고 있어서 일단 추가함. 추후 변경 필요.

### 친구 관련
- friend e2e 테스트에서 불필요한 테스트 케이스 제거 및 잘못된 타입 수정.
  - prisma로 생성된 데이터의 타입은 Entity가 아님. -> 우연히 완전 호환됐던 것.
  - `friendId`로 기능을 수행하므로 발생하는 추가 케이스가 존재함.
  - `userId`를 받아서 수행하는 방식으로 변경해야할듯.


