### PR TITLE
실시간 섬 관련 로직 리팩토링

### DIFF
--- a/src/domain/components/islands/deserted-storage/deserted-island-manager.ts
+++ b/src/domain/components/islands/deserted-storage/deserted-island-manager.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@nestjs/common';
+import { IslandJoinWriter } from 'src/domain/components/island-join/island-join-writer';
+import { DesertedIslandStorageReader } from 'src/domain/components/islands/deserted-storage/deserted-island-storage-reader';
+import { DesertedIslandStorageWriter } from 'src/domain/components/islands/deserted-storage/deserted-island-storage-writer';
+import { IslandManager } from 'src/domain/components/islands/interface/island-manager';
+import { IslandWriter } from 'src/domain/components/islands/island-writer';
+import { PlayerStorageReader } from 'src/domain/components/users/player-storage-reader';
+import { PlayerStorageWriter } from 'src/domain/components/users/player-storage-writer';
+import { IslandJoinEntity } from 'src/domain/entities/island-join/island-join.entity';
+import { ISLAND_FULL } from 'src/domain/exceptions/client-use-messag';
+import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
+import { DomainException } from 'src/domain/exceptions/exceptions';
+import { Player } from 'src/domain/models/game/player';
+import { v4 } from 'uuid';
+
+@Injectable()
+export class DesertedIslandManager implements IslandManager {
+    constructor(
+        private readonly desertedIslandStorageReader: DesertedIslandStorageReader,
+        private readonly desertedIslandStorageWriter: DesertedIslandStorageWriter,
+        private readonly playerStorageReader: PlayerStorageReader,
+        private readonly playerStorageWriter: PlayerStorageWriter,
+        private readonly islandJoinWriter: IslandJoinWriter,
+        private readonly islandWriter: IslandWriter,
+    ) {}
+
+    async canJoin(islandId: string) {
+        const island = await this.desertedIslandStorageReader.readOne(islandId);
+
+        const countParticipants =
+            await this.desertedIslandStorageReader.countPlayer(islandId);
+        if (island.max <= countParticipants) {
+            // 임시 예외 코드
+            throw new DomainException(
+                DomainExceptionType.ISLAND_FULL,
+                1000,
+                ISLAND_FULL,
+            );
+        }
+    }
+
+    async join(player: Player) {
+        const { id: playerId, roomId: islandId } = player;
+
+        await this.playerStorageWriter.create(player);
+        await this.desertedIslandStorageWriter.addPlayer(islandId, playerId);
+
+        const islandJoin = IslandJoinEntity.create(
+            { islandId, userId: playerId },
+            v4,
+        );
+        await this.islandJoinWriter.create(islandJoin);
+    }
+
+    async getActiveUsers(islandId: string, myPlayerId: string) {
+        const island = await this.desertedIslandStorageReader.readOne(islandId);
+
+        const activeUsers: Player[] = [];
+
+        for (const playerId of island.players) {
+            const player = await this.playerStorageReader.readOne(playerId);
+            if (player) {
+                activeUsers.push(player);
+            }
+        }
+
+        return activeUsers.filter((player) => player.id !== myPlayerId);
+    }
+
+    async left(islandId: string, playerId: string) {
+        await this.desertedIslandStorageWriter.removePlayer(islandId, playerId);
+        await this.playerStorageWriter.remove(playerId);
+        await this.islandJoinWriter.left(islandId, playerId);
+    }
+
+    async removeEmpty(islandId: string): Promise<void> {
+        const playerCount =
+            await this.desertedIslandStorageReader.countPlayer(islandId);
+
+        if (playerCount < 1) {
+            await this.desertedIslandStorageWriter.remove(islandId);
+            await this.islandWriter.remove(islandId);
+        }
+    }
+}

--- a/src/domain/components/islands/factory/island-manager-factory.ts
+++ b/src/domain/components/islands/factory/island-manager-factory.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { DesertedIslandManager } from 'src/domain/components/islands/deserted-storage/deserted-island-manager';
+import { IslandManager } from 'src/domain/components/islands/interface/island-manager';
+import { NormalIslandManager } from 'src/domain/components/islands/normal-storage/normal-island-manager';
+import { IslandTypeEnum } from 'src/domain/types/island.types';
+
+@Injectable()
+export class IslandManagerFactory {
+    constructor(
+        private readonly normalIslandManager: NormalIslandManager,
+        private readonly desertedIslandManager: DesertedIslandManager,
+    ) {}
+
+    get(type: IslandTypeEnum): IslandManager {
+        switch (type) {
+            case IslandTypeEnum.NORMAL:
+                return this.normalIslandManager;
+            case IslandTypeEnum.DESERTED:
+                return this.desertedIslandManager;
+            default:
+                throw new Error('Invalid island type');
+        }
+    }
+}

--- a/src/domain/components/islands/interface/island-manager.ts
+++ b/src/domain/components/islands/interface/island-manager.ts
@@ -1,0 +1,9 @@
+import { Player } from 'src/domain/models/game/player';
+
+export interface IslandManager {
+    canJoin(islandId: string): Promise<void>;
+    join(player: Player): Promise<void>;
+    getActiveUsers(islandId: string, myPlayerId: string): Promise<Player[]>;
+    left(islandId: string, playerId: string): Promise<void>;
+    removeEmpty(islandId: string): Promise<void>;
+}

--- a/src/domain/components/islands/normal-storage/normal-island-manager.ts
+++ b/src/domain/components/islands/normal-storage/normal-island-manager.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { v4 } from 'uuid';
 import { IslandJoinWriter } from 'src/domain/components/island-join/island-join-writer';
 import { IslandManager } from 'src/domain/components/islands/interface/island-manager';
 import { IslandWriter } from 'src/domain/components/islands/island-writer';
@@ -11,7 +12,6 @@ import { ISLAND_FULL } from 'src/domain/exceptions/client-use-messag';
 import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
 import { DomainException } from 'src/domain/exceptions/exceptions';
 import { Player } from 'src/domain/models/game/player';
-import { v4 } from 'uuid';
 
 @Injectable()
 export class NormalIslandManager implements IslandManager {
@@ -30,10 +30,9 @@ export class NormalIslandManager implements IslandManager {
         const countParticipants =
             await this.normalIslandStorageReader.countPlayer(islandId);
         if (island.max <= countParticipants) {
-            // 임시 예외 코드
             throw new DomainException(
                 DomainExceptionType.ISLAND_FULL,
-                1000,
+                HttpStatus.UNPROCESSABLE_ENTITY,
                 ISLAND_FULL,
             );
         }

--- a/src/domain/components/islands/normal-storage/normal-island-manager.ts
+++ b/src/domain/components/islands/normal-storage/normal-island-manager.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@nestjs/common';
+import { IslandJoinWriter } from 'src/domain/components/island-join/island-join-writer';
+import { IslandManager } from 'src/domain/components/islands/interface/island-manager';
+import { IslandWriter } from 'src/domain/components/islands/island-writer';
+import { NormalIslandStorageReader } from 'src/domain/components/islands/normal-storage/normal-island-storage-reader';
+import { NormalIslandStorageWriter } from 'src/domain/components/islands/normal-storage/normal-island-storage-writer';
+import { PlayerStorageReader } from 'src/domain/components/users/player-storage-reader';
+import { PlayerStorageWriter } from 'src/domain/components/users/player-storage-writer';
+import { IslandJoinEntity } from 'src/domain/entities/island-join/island-join.entity';
+import { ISLAND_FULL } from 'src/domain/exceptions/client-use-messag';
+import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
+import { DomainException } from 'src/domain/exceptions/exceptions';
+import { Player } from 'src/domain/models/game/player';
+import { v4 } from 'uuid';
+
+@Injectable()
+export class NormalIslandManager implements IslandManager {
+    constructor(
+        private readonly normalIslandStorageReader: NormalIslandStorageReader,
+        private readonly normalIslandStorageWriter: NormalIslandStorageWriter,
+        private readonly playerStorageReader: PlayerStorageReader,
+        private readonly playerStorageWriter: PlayerStorageWriter,
+        private readonly islandJoinWriter: IslandJoinWriter,
+        private readonly islandWriter: IslandWriter,
+    ) {}
+
+    async canJoin(islandId: string) {
+        const island = await this.normalIslandStorageReader.readOne(islandId);
+
+        const countParticipants =
+            await this.normalIslandStorageReader.countPlayer(islandId);
+        if (island.max <= countParticipants) {
+            // 임시 예외 코드
+            throw new DomainException(
+                DomainExceptionType.ISLAND_FULL,
+                1000,
+                ISLAND_FULL,
+            );
+        }
+    }
+
+    async join(player: Player) {
+        const { id: playerId, roomId: islandId } = player;
+
+        await this.playerStorageWriter.create(player);
+        await this.normalIslandStorageWriter.addPlayer(islandId, playerId);
+
+        const islandJoin = IslandJoinEntity.create(
+            { islandId, userId: playerId },
+            v4,
+        );
+        await this.islandJoinWriter.create(islandJoin);
+    }
+
+    async getActiveUsers(islandId: string, myPlayerId: string) {
+        const island = await this.normalIslandStorageReader.readOne(islandId);
+
+        const activeUsers: Player[] = [];
+
+        for (const playerId of island.players) {
+            const player = await this.playerStorageReader.readOne(playerId);
+            if (player) {
+                activeUsers.push(player);
+            }
+        }
+
+        return activeUsers.filter((player) => player.id !== myPlayerId);
+    }
+
+    async left(islandId: string, playerId: string) {
+        await this.normalIslandStorageWriter.removePlayer(islandId, playerId);
+        await this.playerStorageWriter.remove(playerId);
+        await this.islandJoinWriter.left(islandId, playerId);
+    }
+
+    async removeEmpty(islandId: string): Promise<void> {
+        const playerCount =
+            await this.normalIslandStorageReader.countPlayer(islandId);
+
+        if (playerCount < 1) {
+            await this.normalIslandStorageWriter.remove(islandId);
+            await this.islandWriter.remove(islandId);
+        }
+    }
+}

--- a/src/domain/models/game/player.ts
+++ b/src/domain/models/game/player.ts
@@ -31,27 +31,6 @@ export class Player {
         public lastActivity: number,
     ) {}
 
-    update<K extends keyof Omit<Player, 'id' | 'clientId'>>(
-        key: K,
-        value: Player[K],
-    ) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        (this as any)[key] = value;
-        this.lastActivity = Date.now();
-    }
-
-    setPosition(x: number, y: number) {
-        this.x = x;
-        this.y = y;
-
-        this.lastMoved = Date.now();
-        this.updateLastActivity();
-    }
-
-    updateLastActivity() {
-        this.lastActivity = Date.now();
-    }
-
     static create(proto: PlayerPrototype) {
         const now = Date.now();
 

--- a/src/domain/services/game/game.service.ts
+++ b/src/domain/services/game/game.service.ts
@@ -35,7 +35,9 @@ export class GameService {
         player.isFacingRight =
             player.x < x ? true : player.x > x ? false : player.isFacingRight;
 
-        player.setPosition(x, y);
+        player.x = x;
+        player.y = y;
+
         return player;
     }
 
@@ -74,7 +76,7 @@ export class GameService {
             .filter((player) => player !== null)
             .filter((player) => player.id !== attacker.id)
             .filter((player) => this.isInAttackBox(player, attackBox));
-        attacker.updateLastActivity();
+        attacker.lastActivity = Date.now();
 
         return {
             attacker,

--- a/src/modules/game/game.module.ts
+++ b/src/modules/game/game.module.ts
@@ -15,6 +15,7 @@ import { TagComponentModule } from 'src/modules/tags/tag-component.module';
 import { IslandTagComponentModule } from 'src/modules/island-tags/island-tag-component.module';
 import { PlayerStorageComponentModule } from 'src/modules/users/player-storage-component.module';
 import { PlayerMemoryStorageComponentModule } from 'src/modules/users/player-memory-storage-component.module';
+import { IslandManagerFactoryModule } from 'src/modules/islands/island-manager-factory.module';
 
 @Module({
     imports: [
@@ -29,6 +30,8 @@ import { PlayerMemoryStorageComponentModule } from 'src/modules/users/player-mem
         PlayerMemoryStorageComponentModule,
         NormalIslandStorageComponentModule,
         DesertedIslandStorageComponentModule,
+
+        IslandManagerFactoryModule,
     ],
     providers: [
         LobyGateway,

--- a/src/modules/islands/deserted-island-manager.module.ts
+++ b/src/modules/islands/deserted-island-manager.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { DesertedIslandManager } from 'src/domain/components/islands/deserted-storage/deserted-island-manager';
+import { IslandJoinComponentModule } from 'src/modules/island-joins/island-join-component.module';
+import { DesertedIslandStorageComponentModule } from 'src/modules/islands/deserted-island-storage-component.module';
+import { IslandComponentModule } from 'src/modules/islands/island-component.module';
+import { PlayerStorageComponentModule } from 'src/modules/users/player-storage-component.module';
+
+@Module({
+    imports: [
+        DesertedIslandStorageComponentModule,
+        PlayerStorageComponentModule,
+        IslandJoinComponentModule,
+        IslandComponentModule,
+    ],
+    providers: [DesertedIslandManager],
+    exports: [DesertedIslandManager],
+})
+export class DesertedIslandManagerModule {}

--- a/src/modules/islands/island-manager-factory.module.ts
+++ b/src/modules/islands/island-manager-factory.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { IslandManagerFactory } from 'src/domain/components/islands/factory/island-manager-factory';
+import { DesertedIslandManagerModule } from 'src/modules/islands/deserted-island-manager.module';
+import { NormalIslandManagerModule } from 'src/modules/islands/normal-island-manager.module';
+
+@Module({
+    imports: [NormalIslandManagerModule, DesertedIslandManagerModule],
+    providers: [IslandManagerFactory],
+    exports: [IslandManagerFactory],
+})
+export class IslandManagerFactoryModule {}

--- a/src/modules/islands/normal-island-manager.module.ts
+++ b/src/modules/islands/normal-island-manager.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { NormalIslandManager } from 'src/domain/components/islands/normal-storage/normal-island-manager';
+import { IslandJoinComponentModule } from 'src/modules/island-joins/island-join-component.module';
+import { IslandComponentModule } from 'src/modules/islands/island-component.module';
+import { NormalIslandStorageComponentModule } from 'src/modules/islands/normal-island-storage-component.module';
+import { PlayerStorageComponentModule } from 'src/modules/users/player-storage-component.module';
+
+@Module({
+    imports: [
+        NormalIslandStorageComponentModule,
+        PlayerStorageComponentModule,
+        IslandJoinComponentModule,
+        IslandComponentModule,
+    ],
+    providers: [NormalIslandManager],
+    exports: [NormalIslandManager],
+})
+export class NormalIslandManagerModule {}


### PR DESCRIPTION
## 작업 내용
- `GameIslandService`에서 너무 많은 세부 로직이 드러나고 있고 조건 분기 및 반복이 많아서 기능을 조금 쪼개서 `component` 레이어로 위임.
  - 추가된 `class` 및 `interface` (Module 클래스 제외)
    - IslandManager (interface), NormalIslansManager, DesertedIslandManager, IslandManagerFactory
  - 섬 종류 별로 세부 로직을 관리하는 `manager`를 구현하고, `island type`에 따라 원하는 `manager`를 반환하는 `factory` 구현.
  - `GameIslandService`에서는 `factory`만 주입 받아서 `manager`를 사용.
  - `manager`는 `interface`를 상속해서 구현함.
  - 새로운 섬 종류가 추가되면 `interface`를 상속하여  `manager`구현 후 `factory`에만 등록하고 사용하면 됨.
- `Player class`를 모든 저장소에서 재사용하고 싶은데 메서드가 있으면 Redis에서 데이터 매핑 시 불편해져서 update 메서드들 제거.