### PR TITLE
실시간 관련 코드 리팩토링

### DIFF
--- a/src/constants/game/hit-box.ts
+++ b/src/constants/game/hit-box.ts
@@ -1,5 +1,5 @@
 export const PLAYER_HIT_BOX = {
     PAWN: {
-        RADIUS: 20,
+        RADIUS: 15,
     },
 };

--- a/src/domain/components/game/game-attack-manager.ts
+++ b/src/domain/components/game/game-attack-manager.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import { ATTACK_BOX_SIZE } from 'src/constants/game/attack-box';
+import { PLAYER_HIT_BOX } from 'src/constants/game/hit-box';
+import { PlayerMemoryStorageManager } from 'src/domain/components/users/player-memory-storage-manager';
+import { Player } from 'src/domain/models/game/player';
+import { Position, Rectangle } from 'src/domain/types/game.types';
+import { isCircleInRect } from 'src/utils/game/collision';
+
+@Injectable()
+export class GameAttackManager {
+    constructor(
+        private readonly playerMemoryStorageManager: PlayerMemoryStorageManager,
+    ) {}
+
+    calcAttackRangeBox(attacker: Player) {
+        // TODO 아바타 추가되면 avatarKey에 따라 분기
+        const boxSize = ATTACK_BOX_SIZE.PAWN;
+        const attackBox = {
+            x: attacker.isFacingRight
+                ? attacker.x + boxSize.width / 2
+                : attacker.x - boxSize.width / 2,
+            y: attacker.y,
+            width: boxSize.width,
+            height: boxSize.height,
+        };
+
+        return attackBox;
+    }
+
+    findTargetsInBox(
+        playerIds: string[],
+        attackerId: string,
+        attackRangeBox: Rectangle,
+    ) {
+        return playerIds.reduce((acc, playerId) => {
+            if (playerId === attackerId) return acc;
+            let player: Player;
+
+            try {
+                player = this.playerMemoryStorageManager.readOne(playerId);
+            } catch (_) {
+                return acc;
+            }
+
+            if (this.isInAttackBox(player, attackRangeBox)) {
+                acc.push(player);
+            }
+            return acc;
+        }, [] as Player[]);
+    }
+
+    isInAttackBox(targetPosition: Position, box: Rectangle) {
+        // TODO 캐릭터 추가되면 상수로 관리
+        const radius = PLAYER_HIT_BOX.PAWN.RADIUS;
+        const isHit = isCircleInRect({ ...targetPosition, radius }, box);
+
+        return isHit;
+    }
+}

--- a/src/domain/components/game/game-player-manager.ts
+++ b/src/domain/components/game/game-player-manager.ts
@@ -27,10 +27,10 @@ export class GamePlayerManager {
     }
 
     async updateLastActivity(player: Player, now = Date.now()) {
-        if (player.lastActivity + 1000 * 60 < now) {
+        if (player.lastActivity + 1000 * 20 < now) {
             this.playerMemoryStorageManager.updateLastActivity(player.id);
         }
-        if (player.lastActivity + 1000 * 60 * 5 < now) {
+        if (player.lastActivity + 1000 * 60 * 3 < now) {
             await this.playerStorageWriter.updateLastActivity(player.id);
         }
     }

--- a/src/domain/components/islands/factory/island-storage-reader-factory.ts
+++ b/src/domain/components/islands/factory/island-storage-reader-factory.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { DesertedIslandStorageReader } from 'src/domain/components/islands/deserted-storage/deserted-island-storage-reader';
+import { NormalIslandStorageReader } from 'src/domain/components/islands/normal-storage/normal-island-storage-reader';
+import { IslandTypeEnum } from 'src/domain/types/island.types';
+
+interface IslandReaderTypeMap {
+    [IslandTypeEnum.NORMAL]: NormalIslandStorageReader;
+    [IslandTypeEnum.DESERTED]: DesertedIslandStorageReader;
+}
+
+@Injectable()
+export class IslandStorageReaderFactory {
+    constructor(
+        private readonly normalIslandStorageReader: NormalIslandStorageReader,
+        private readonly desertedIslandStorageReader: DesertedIslandStorageReader,
+    ) {}
+
+    get<T extends IslandTypeEnum>(type: T): IslandReaderTypeMap[T] {
+        switch (type) {
+            case IslandTypeEnum.NORMAL:
+                return this.normalIslandStorageReader as IslandReaderTypeMap[T];
+            case IslandTypeEnum.DESERTED:
+                return this
+                    .desertedIslandStorageReader as IslandReaderTypeMap[T];
+            default:
+                throw new Error(`Unknown island type: ${type}`);
+        }
+    }
+}

--- a/src/domain/components/users/player-memory-storage-manager.ts
+++ b/src/domain/components/users/player-memory-storage-manager.ts
@@ -35,4 +35,8 @@ export class PlayerMemoryStorageManager {
     remove(id: string) {
         this.playerMemoryStorage.deletePlayer(id);
     }
+
+    updateLastActivity(id: string, time = Date.now()) {
+        this.playerMemoryStorage.updateLastActivity(id, time);
+    }
 }

--- a/src/domain/components/users/player-storage-writer.ts
+++ b/src/domain/components/users/player-storage-writer.ts
@@ -23,6 +23,5 @@ export class PlayerStorageWriter {
 
     async updateLastActivity(id: string, time = Date.now()) {
         await this.playerStorage.updateLastActivity(id, time);
-        this.playerMemoryStorage.updateLastActivity(id, time);
     }
 }

--- a/src/domain/services/game/game.service.ts
+++ b/src/domain/services/game/game.service.ts
@@ -45,15 +45,12 @@ export class GameService {
 
     async attack(attackerId: string) {
         const attacker = this.playerMemoryStorageManager.readOne(attackerId);
-        if (!attacker) throw new Error('없는 회원');
+        const { roomId: islandId, islandType } = attacker;
 
         const island =
-            attacker.islandType === IslandTypeEnum.NORMAL
-                ? await this.normalIslandStorageReader.readOne(attacker.roomId)
-                : await this.desertedIslandStorageReader.readOne(
-                      attacker.roomId,
-                  );
-        if (!island) throw new Error('없는 섬');
+            islandType === IslandTypeEnum.NORMAL
+                ? await this.normalIslandStorageReader.readOne(islandId)
+                : await this.desertedIslandStorageReader.readOne(islandId);
 
         if (island.players.size === 0) {
             return {
@@ -124,15 +121,12 @@ export class GameService {
         playerId: string,
     ): Promise<{ id: string; lastActivity: number }[]> {
         const player = this.playerMemoryStorageManager.readOne(playerId);
+        const { islandType, roomId: islandId } = player;
 
         const playerIds =
-            player.islandType === IslandTypeEnum.NORMAL
-                ? await this.normalIslandStorageReader.getAllPlayer(
-                      player.roomId,
-                  )
-                : await this.desertedIslandStorageReader.getAllPlayer(
-                      player.roomId,
-                  );
+            islandType === IslandTypeEnum.NORMAL
+                ? await this.normalIslandStorageReader.getAllPlayer(islandId)
+                : await this.desertedIslandStorageReader.getAllPlayer(islandId);
 
         const players = playerIds
             .map((playerId) => {

--- a/src/domain/services/game/game.service.ts
+++ b/src/domain/services/game/game.service.ts
@@ -7,6 +7,8 @@ import { NormalIslandStorageReader } from 'src/domain/components/islands/normal-
 import { DesertedIslandStorageReader } from 'src/domain/components/islands/deserted-storage/deserted-island-storage-reader';
 import { PlayerMemoryStorageManager } from 'src/domain/components/users/player-memory-storage-manager';
 import { GamePlayerManager } from 'src/domain/components/game/game-player-manager';
+import { Position, Rectangle } from 'src/domain/types/game.types';
+import { isCircleInRect } from 'src/utils/game/collision';
 
 @Injectable()
 export class GameService {
@@ -76,36 +78,12 @@ export class GameService {
         };
     }
 
-    isInAttackBox(
-        player: Player,
-        box: { x: number; y: number; width: number; height: number },
-    ) {
-        // 캐릭터 추가되면 상수로 관리
-        const playerRadius = PLAYER_HIT_BOX.PAWN.RADIUS;
+    isInAttackBox(targetPosition: Position, box: Rectangle) {
+        // TODO 캐릭터 추가되면 상수로 관리
+        const radius = PLAYER_HIT_BOX.PAWN.RADIUS;
+        const isHit = isCircleInRect({ ...targetPosition, radius }, box);
 
-        const boxLeft = box.x - box.width / 2;
-        const boxRight = box.x + box.width / 2;
-        const boxTop = box.y - box.height / 2;
-        const boxBottom = box.y + box.height / 2;
-
-        if (
-            player.x >= boxLeft &&
-            player.x <= boxRight &&
-            player.y >= boxTop &&
-            player.y <= boxBottom
-        ) {
-            return true;
-        }
-
-        const closestX = Math.max(boxLeft, Math.min(player.x, boxRight));
-        const closestY = Math.max(boxTop, Math.min(player.y, boxBottom));
-
-        const distanceX = player.x - closestX;
-        const distanceY = player.y - closestY;
-
-        const distanceSquared = distanceX * distanceX + distanceY * distanceY;
-
-        return distanceSquared < playerRadius * playerRadius;
+        return isHit;
     }
 
     async hearbeatFromIsland(

--- a/src/domain/types/game.types.ts
+++ b/src/domain/types/game.types.ts
@@ -38,3 +38,21 @@ export interface JoinedIslandInfo {
     readonly joinedIslandId: string;
     readonly joinedPlayer: Player;
 }
+
+export interface Rectangle {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export interface Circle {
+    x: number;
+    y: number;
+    radius: number;
+}
+
+export interface Position {
+    x: number;
+    y: number;
+}

--- a/src/domain/types/game.types.ts
+++ b/src/domain/types/game.types.ts
@@ -3,18 +3,16 @@ import { IslandTypeEnum } from 'src/domain/types/island.types';
 
 export type SocketClientId = string;
 
-export interface LiveDesertedIsland {
+export interface LiveIsland {
     id: string;
     players: Set<string>;
     type: IslandTypeEnum;
     max: number;
 }
 
-export interface LiveNormalIsland {
-    id: string;
-    players: Set<string>;
-    type: IslandTypeEnum;
-    max: number;
+export type LiveDesertedIsland = LiveIsland;
+
+export interface LiveNormalIsland extends LiveIsland {
     name: string;
     description: string;
     coverImage: string;

--- a/src/modules/game/game-component.module.ts
+++ b/src/modules/game/game-component.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { GamePlayerManager } from 'src/domain/components/game/game-player-manager';
+import { PlayerMemoryStorageComponentModule } from 'src/modules/users/player-memory-storage-component.module';
+import { PlayerStorageComponentModule } from 'src/modules/users/player-storage-component.module';
+
+@Module({
+    imports: [PlayerStorageComponentModule, PlayerMemoryStorageComponentModule],
+    providers: [GamePlayerManager],
+    exports: [GamePlayerManager],
+})
+export class GameComponentModule {}

--- a/src/modules/game/game-component.module.ts
+++ b/src/modules/game/game-component.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { GameAttackManager } from 'src/domain/components/game/game-attack-manager';
 import { GamePlayerManager } from 'src/domain/components/game/game-player-manager';
 import { PlayerMemoryStorageComponentModule } from 'src/modules/users/player-memory-storage-component.module';
 import { PlayerStorageComponentModule } from 'src/modules/users/player-storage-component.module';
 
 @Module({
     imports: [PlayerStorageComponentModule, PlayerMemoryStorageComponentModule],
-    providers: [GamePlayerManager],
-    exports: [GamePlayerManager],
+    providers: [GamePlayerManager, GameAttackManager],
+    exports: [GamePlayerManager, GameAttackManager],
 })
 export class GameComponentModule {}

--- a/src/modules/game/game.module.ts
+++ b/src/modules/game/game.module.ts
@@ -21,6 +21,7 @@ import { FriendGateway } from 'src/presentation/gateway/friend.gateway';
 import { FriendsModule } from 'src/modules/friends/friends.module';
 import { WsConnectionAuthenticator } from 'src/common/ws-auth/ws-connection-authenticator';
 import { GameComponentModule } from 'src/modules/game/game-component.module';
+import { IslandStorageReaderFactoryModule } from 'src/modules/islands/island-storage-reader-factory.module';
 
 @Module({
     imports: [
@@ -38,6 +39,7 @@ import { GameComponentModule } from 'src/modules/game/game-component.module';
         NormalIslandStorageComponentModule,
         DesertedIslandStorageComponentModule,
 
+        IslandStorageReaderFactoryModule,
         IslandManagerFactoryModule,
         RedisTransactionManagerModule,
     ],

--- a/src/modules/game/game.module.ts
+++ b/src/modules/game/game.module.ts
@@ -20,9 +20,11 @@ import { RedisTransactionManagerModule } from 'src/infrastructure/redis/redis-tr
 import { FriendGateway } from 'src/presentation/gateway/friend.gateway';
 import { FriendsModule } from 'src/modules/friends/friends.module';
 import { WsConnectionAuthenticator } from 'src/common/ws-auth/ws-connection-authenticator';
+import { GameComponentModule } from 'src/modules/game/game-component.module';
 
 @Module({
     imports: [
+        GameComponentModule,
         UserComponentModule,
         IslandComponentModule,
         IslandJoinComponentModule,

--- a/src/modules/islands/island-storage-reader-factory.module.ts
+++ b/src/modules/islands/island-storage-reader-factory.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { IslandStorageReaderFactory } from 'src/domain/components/islands/factory/island-storage-reader-factory';
+import { DesertedIslandStorageComponentModule } from 'src/modules/islands/deserted-island-storage-component.module';
+import { NormalIslandStorageComponentModule } from 'src/modules/islands/normal-island-storage-component.module';
+
+@Module({
+    imports: [
+        NormalIslandStorageComponentModule,
+        DesertedIslandStorageComponentModule,
+    ],
+    providers: [IslandStorageReaderFactory],
+    exports: [IslandStorageReaderFactory],
+})
+export class IslandStorageReaderFactoryModule {}

--- a/src/presentation/gateway/island.gateway.ts
+++ b/src/presentation/gateway/island.gateway.ts
@@ -24,6 +24,7 @@ import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception
 import { WsExceptionFilter } from 'src/common/filter/ws-exception.filter';
 import { WsConnectionAuthenticator } from 'src/common/ws-auth/ws-connection-authenticator';
 import { WsExceptions } from 'src/presentation/dto/game/socket/known-exception';
+import { PlayerStorageReader } from 'src/domain/components/users/player-storage-reader';
 
 type TypedSocket = Socket<ClientToIsland, IslandToClient>;
 
@@ -45,6 +46,7 @@ export class IslandGateway
 
     constructor(
         private readonly wsConnectionAuthenticator: WsConnectionAuthenticator,
+        private readonly playerStorageReader: PlayerStorageReader,
         private readonly gameService: GameService,
         private readonly gameIslandService: GameIslandService,
     ) {}
@@ -163,11 +165,11 @@ export class IslandGateway
     }
 
     @SubscribeMessage('jump')
-    jump(
+    async jump(
         @ConnectedSocket() client: TypedSocket,
         @CurrentUserFromSocket() userId: string,
     ) {
-        const { roomId } = this.gameService.getPlayer(userId);
+        const { roomId } = await this.playerStorageReader.readOne(userId);
         client.to(roomId).emit('jump', userId);
     }
 

--- a/src/presentation/gateway/island.gateway.ts
+++ b/src/presentation/gateway/island.gateway.ts
@@ -133,12 +133,12 @@ export class IslandGateway
     }
 
     @SubscribeMessage('playerMoved')
-    handlePlayerMoved(
+    async handlePlayerMoved(
         @MessageBody() data: { x: number; y: number },
         @ConnectedSocket() client: TypedSocket,
         @CurrentUserFromSocket() userId: string,
     ) {
-        const movedPlayer = this.gameService.move(userId, data.x, data.y);
+        const movedPlayer = await this.gameService.move(userId, data.x, data.y);
         if (movedPlayer) {
             client.to(movedPlayer.roomId).emit('playerMoved', {
                 id: movedPlayer.id,

--- a/src/utils/game/collision.ts
+++ b/src/utils/game/collision.ts
@@ -1,0 +1,26 @@
+import { Circle, Rectangle } from 'src/domain/types/game.types';
+
+export const isCircleInRect = (circle: Circle, rect: Rectangle): boolean => {
+    const rectLeft = rect.x - rect.width / 2;
+    const rectRight = rect.x + rect.width / 2;
+    const rectTop = rect.y - rect.height / 2;
+    const rectBottom = rect.y + rect.height / 2;
+
+    if (
+        circle.x >= rectLeft &&
+        circle.x <= rectRight &&
+        circle.y >= rectTop &&
+        circle.y <= rectBottom
+    ) {
+        return true;
+    }
+
+    const closestX = Math.max(rectLeft, Math.min(circle.x, rectRight));
+    const closestY = Math.max(rectTop, Math.min(circle.y, rectBottom));
+
+    const dx = circle.x - closestX;
+    const dy = circle.y - closestY;
+
+    const distanceSq = dx * dx + dy * dy;
+    return distanceSq < circle.radius * circle.radius;
+};

--- a/test/unit/utils/collision.unit-spec.ts
+++ b/test/unit/utils/collision.unit-spec.ts
@@ -1,0 +1,36 @@
+import type { Circle, Rectangle } from 'src/domain/types/game.types';
+import { isCircleInRect } from 'src/utils/game/collision';
+
+describe('isCircleInRect - 원과 사각형 충돌 판정', () => {
+    const rectangle: Rectangle = { x: 0, y: 0, width: 10, height: 10 };
+
+    it('원이 사각형 안에 완전히 들어갈 경우 충돌', () => {
+        const circle: Circle = { x: 0, y: 0, radius: 1 };
+        expect(isCircleInRect(circle, rectangle)).toBe(true);
+    });
+
+    it('원의 중심이 사각형 경계 위에 있는 경우 충돌', () => {
+        const circle: Circle = { x: 5, y: 0, radius: 1 };
+        expect(isCircleInRect(circle, rectangle)).toBe(true);
+    });
+
+    it('원의 일부가 사각형과 겹치는 경우 충돌', () => {
+        const circle: Circle = { x: 6, y: 0, radius: 2 };
+        expect(isCircleInRect(circle, rectangle)).toBe(true);
+    });
+
+    it('원이 사각형 밖에 완전히 있는 경우 충돌 X', () => {
+        const circle: Circle = { x: 20, y: 20, radius: 1 };
+        expect(isCircleInRect(circle, rectangle)).toBe(false);
+    });
+
+    it('원이 사각형에 딱 닿기만 할 경우 충돌 X', () => {
+        const circle: Circle = { x: 6, y: 0, radius: 1 };
+        expect(isCircleInRect(circle, rectangle)).toBe(false);
+    });
+
+    it('원의 중심은 밖에 있지만 모서리에 닿는 경우 충돌', () => {
+        const circle: Circle = { x: 6, y: 6, radius: 2 };
+        expect(isCircleInRect(circle, rectangle)).toBe(true);
+    });
+});


### PR DESCRIPTION
## 작업 내용
- 메모리와 redis에서 플레이어 마지막 활동 시간을 따로 업데이트 해야하는 경우가 생겨서 한 번에 처리하던 걸 따로 분리
- 이제 `move` 시에도 마지막 활동 시간 업데이트를 함.
  - 메모리에는 20초에 한 번, redis에는 3분에 한 번
- 실시간 기능에 자주 사용되는 타입 분리 `Position` `Circle` `Rectangle`
- `gameService`에 노출된 상세 구현 로직을 `gameManager`와 `gameAttackManager`로 위임.
  - 공격은 코드가 많아서 따로 분리했음.
  - 공격 코드 중 공격자의 공격 범위에 속하는 회원을 검색할 때, 히트 박스의 오버랩 계산 함수는 `util` 함수로 따로 분리함.
- `gameService`에서 섬 타입에 따라 분기하던 조회 코드 제거를 위해 `IslandStorageReaderFactory` 클래스 구현.
  - 확장 시에도 service 수정 불필요