### PR TITLE
msgpack adapter 구현 및 버전 일치 검사

### DIFF
--- a/src/constants/version.ts
+++ b/src/constants/version.ts
@@ -1,0 +1,6 @@
+export const APP_VERSION = '1.0.0';
+const version = APP_VERSION.split('.');
+
+export const MAJOR = version[0];
+export const MINOR = version[1];
+export const PATCH = version[2];

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,12 +3,16 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import * as cookieParser from 'cookie-parser';
 import { AppModule } from 'src/app.module';
 import { setupSwagger } from 'src/configs/swagger/setup-swagger';
+import { MessagePackIoAdapter } from 'src/presentation/gateway/adapter/msg-pack-adapter';
 
 async function bootstrap() {
     const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
+    const wsAdapter = new MessagePackIoAdapter(app);
+
     app.enableCors({ origin: true });
     app.use(cookieParser());
+    app.useWebSocketAdapter(wsAdapter);
     setupSwagger(app);
 
     await app.listen(3000);

--- a/src/presentation/dto/game/socket/type.ts
+++ b/src/presentation/dto/game/socket/type.ts
@@ -61,6 +61,7 @@ export type IslandToClient = {
     attacked: (data: AttackedResponse) => void;
     islandHearbeat: (data: IslandHeartbeatResponse) => void;
     jump: (userId: string) => void;
+    invalidVersion: () => void;
 } & ErrorToClient;
 
 export type ClientToFriend = {

--- a/src/presentation/gateway/adapter/msg-pack-adapter.ts
+++ b/src/presentation/gateway/adapter/msg-pack-adapter.ts
@@ -1,0 +1,14 @@
+// socket-io.adapter.ts
+import { IoAdapter } from '@nestjs/platform-socket.io';
+import { ServerOptions } from 'socket.io';
+import * as msgpackParser from 'socket.io-msgpack-parser';
+
+export class MessagePackIoAdapter extends IoAdapter {
+    createIOServer(port: number, options?: ServerOptions): any {
+        if (options) {
+            options.parser = msgpackParser;
+        }
+
+        return super.createIOServer(port, options);
+    }
+}

--- a/src/presentation/gateway/island.gateway.ts
+++ b/src/presentation/gateway/island.gateway.ts
@@ -25,6 +25,7 @@ import { WsExceptionFilter } from 'src/common/filter/ws-exception.filter';
 import { WsConnectionAuthenticator } from 'src/common/ws-auth/ws-connection-authenticator';
 import { WsExceptions } from 'src/presentation/dto/game/socket/known-exception';
 import { PlayerStorageReader } from 'src/domain/components/users/player-storage-reader';
+import { checkAppVersion } from 'test/unit/utils/check-app-version';
 
 type TypedSocket = Socket<ClientToIsland, IslandToClient>;
 
@@ -178,6 +179,13 @@ export class IslandGateway
         @ConnectedSocket() client: TypedSocket,
         @CurrentUserFromSocket() userId: string,
     ) {
+        const appVersion = client.handshake.auth['app-version'] as
+            | string
+            | undefined;
+        if (!checkAppVersion(appVersion)) client.emit('invalidVersion');
+
+        this.logger.debug(appVersion);
+
         const heartbeats = await this.gameService.hearbeatFromIsland(userId);
 
         client.emit('islandHearbeat', heartbeats);

--- a/test/unit/utils/check-app-version.ts
+++ b/test/unit/utils/check-app-version.ts
@@ -1,0 +1,10 @@
+import { MAJOR, MINOR } from 'src/constants/version';
+
+export const checkAppVersion = (version: string | string[] | undefined) => {
+    if (typeof version !== 'string') return false;
+
+    const versionArr = version.split('.');
+    if (versionArr[0] !== MAJOR || versionArr[1] !== MINOR) return false;
+
+    return true;
+};

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mmorntype",
-    "version": "1.0.60",
+    "version": "1.0.61",
     "description": "mmorn dto type",
     "typings": "./dist/types/index.d.ts",
     "files": [


### PR DESCRIPTION
## 작업 내용
- `ws` 통신시 기존 `json` 포멧에서 `msgpack` 바이너리 포맷으로 변경

### 버전 검사
- 클라이언트에서 플레이에 영향을 줄만한 변경이 발생했을 경우, 강제적으로 플레이어들의 버전을 일치시키기 위해 구현.
- 로비는 싱글 플레이 화면이기에 버전 확인 불필요.
- 섬 화면에서 하트비트 체크 시에 버전 정보 비교 로직 추가.
  - `major` 혹은  `minor` 버전이 불일치할 경우 `invalidVersion` 이벤트 송신.
  - 버전 일치가 불필요한 변경의 경우 `patch`만 업데이트하면 됨.