### PR TITLE
토큰 재발급 수정 및 로그아웃 구현

### DIFF
--- a/src/configs/cookie-options.ts
+++ b/src/configs/cookie-options.ts
@@ -3,7 +3,7 @@ import { CookieOptions } from 'express';
 export const cookieOptions = (): CookieOptions => ({
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
-    sameSite: 'none',
+    sameSite: 'lax',
     domain: process.env.NODE_ENV === 'production' ? 'livisland.com' : undefined,
     maxAge: Number(process.env.REFRESH_COOKIE_TIME),
 });

--- a/src/domain/services/auth/auth.service.ts
+++ b/src/domain/services/auth/auth.service.ts
@@ -118,6 +118,10 @@ export class AuthService {
                 userId,
                 this.accessTokenExpiration,
             ),
+            refreshToken: await this.generateToken(
+                userId,
+                this.refreshTokenExpiration,
+            ),
         };
     }
 

--- a/src/presentation/controller/auth/auth.controller.ts
+++ b/src/presentation/controller/auth/auth.controller.ts
@@ -3,12 +3,11 @@ import {
     Controller,
     Param,
     Post,
-    Req,
     Res,
     UseFilters,
     UseGuards,
 } from '@nestjs/common';
-import { Response, Request } from 'express';
+import { Response } from 'express';
 import { AuthService } from 'src/domain/services/auth/auth.service';
 import { Provider } from 'src/shared/types';
 import { LoginRequest } from 'src/presentation/dto/auth/request/login.request';
@@ -128,7 +127,6 @@ export class AuthController {
     @UseGuards(RefreshTokenGuard)
     @Post('token')
     async refreshToken(
-        @Req() request: Request,
         @Res({ passthrough: true }) response: Response,
         @CurrentUser('userId') userId: string,
     ): Promise<RefreshTokenResponse> {

--- a/src/presentation/controller/auth/auth.controller.ts
+++ b/src/presentation/controller/auth/auth.controller.ts
@@ -127,7 +127,12 @@ export class AuthController {
     @Post('refresh')
     async refreshToken(
         @CurrentUser() userId: string,
+        @Res({ passthrough: true }) response: Response,
     ): Promise<RefreshTokenResponse> {
-        return await this.authService.refresToken(userId);
+        const { accessToken, refreshToken } =
+            await this.authService.refresToken(userId);
+        response.cookie('refresh_token', refreshToken, cookieOptions());
+
+        return { accessToken };
     }
 }

--- a/src/presentation/controller/auth/auth.controller.ts
+++ b/src/presentation/controller/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import {
     Body,
     Controller,
+    Delete,
     Param,
     Post,
     Res,
@@ -136,5 +137,23 @@ export class AuthController {
         response.cookie('refresh_token', refreshToken, cookieOptions());
 
         return { accessToken };
+    }
+
+    @ApiOperation({
+        summary: '로그아웃',
+        description: 'Refresh Token 삭제.',
+    })
+    @ApiResponse({
+        status: 204,
+        description: '로그인 성공',
+    })
+    @ApiResponse({ status: 404, description: '가입되지 않은 회원' })
+    @ApiResponse({
+        status: 409,
+        description: '다른 플랫폼으로 가입한 이력 존재',
+    })
+    @Delete('logout')
+    logout(@Res({ passthrough: true }) response: Response): void {
+        response.clearCookie('refresh_token', cookieOptions());
     }
 }


### PR DESCRIPTION
## 작업 내용
- 로그아웃 api 추가
  - 현재는 단순 `refresh token` 삭제
- `body`로 응답하던 재발급된 `refresh token`을  `cookie`로 이전
- `cookie`의 `samesite` 속성 `lax`로 변경