### PR TITLE
일반 섬 조회 기능 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,7 @@ import { TagModule } from 'src/modules/tags/tag.module';
 import { LoaderModule } from 'src/modules/loaders/loader.module';
 import { RedisModule } from 'src/infrastructure/redis/redis.module';
 import { validationSchema } from 'src/env-validation';
+import { IslandModule } from 'src/modules/islands/island.module';
 
 @Module({
     imports: [
@@ -39,6 +40,7 @@ import { validationSchema } from 'src/env-validation';
         PurchaseModule,
         FileModule,
         TagModule,
+        IslandModule,
 
         LoaderModule,
     ],

--- a/src/domain/entities/islands/island.entity.ts
+++ b/src/domain/entities/islands/island.entity.ts
@@ -1,6 +1,16 @@
 import { IslandTypeEnum } from 'src/domain/types/island.types';
 
-export class IslandPrototype {
+export interface NormalIslandPrototype {
+    readonly maxMembers: number;
+    readonly type: IslandTypeEnum;
+    readonly name: string;
+    readonly description: string;
+    readonly coverImage: string;
+    readonly ownerId: string;
+    readonly deletedAt?: Date;
+}
+
+export interface IslandPrototype {
     readonly maxMembers: number;
     readonly tag?: string;
     readonly type: IslandTypeEnum;

--- a/src/domain/services/game/game-island-create.service.ts
+++ b/src/domain/services/game/game-island-create.service.ts
@@ -1,6 +1,9 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
 import { IslandWriter } from 'src/domain/components/islands/island-writer';
-import { IslandPrototype } from 'src/domain/entities/islands/island.entity';
+import {
+    IslandPrototype,
+    NormalIslandPrototype,
+} from 'src/domain/entities/islands/island.entity';
 import { IslandTypeEnum } from 'src/domain/types/island.types';
 import { DomainException } from 'src/domain/exceptions/exceptions';
 import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
@@ -9,17 +12,20 @@ import { TAG_AT_LEAST_ONE_MESSAGE } from 'src/domain/exceptions/message';
 import { Transactional } from '@nestjs-cls/transactional';
 import { IslandTagWriter } from 'src/domain/components/island-tags/island-tag-writer';
 import { NormalIslandStorageWriter } from 'src/domain/components/islands/normal-storage/normal-island-storage-writer';
+import { UserReader } from 'src/domain/components/users/user-reader';
 
 @Injectable()
 export class GameIslandCreateService {
     constructor(
+        private readonly userReader: UserReader,
         private readonly normalIslandStorageWriter: NormalIslandStorageWriter,
         private readonly islandWriter: IslandWriter,
         private readonly tagReader: TagReader,
         private readonly islandTagWriter: IslandTagWriter,
     ) {}
 
-    async create(prototype: IslandPrototype, tagNames: string[]) {
+    async create(prototype: NormalIslandPrototype, tagNames: string[]) {
+        const owner = await this.userReader.readProfile(prototype.ownerId);
         const tags = await this.tagReader.readByNames(tagNames);
 
         if (tags.length < 1) {
@@ -35,7 +41,7 @@ export class GameIslandCreateService {
             tags.map((tag) => tag.id),
         );
 
-        const normalIsland = {
+        await this.normalIslandStorageWriter.create({
             id: island.id,
             max: island.maxMembers,
             players: new Set<string>(),
@@ -45,8 +51,8 @@ export class GameIslandCreateService {
             description: island.description || '알 수 없는 섬',
             name: island.name || '알 수 없는 섬',
             tags: tagNames,
-        };
-        await this.normalIslandStorageWriter.create(normalIsland);
+            ownerId: owner.id,
+        });
 
         return island.id;
     }

--- a/src/domain/types/game.types.ts
+++ b/src/domain/types/game.types.ts
@@ -17,6 +17,7 @@ export interface LiveNormalIsland extends LiveIsland {
     description: string;
     coverImage: string;
     tags: string[];
+    ownerId: string;
     createdAt: Date;
 }
 

--- a/src/infrastructure/redis/islands/normal-island-redis-storage.ts
+++ b/src/infrastructure/redis/islands/normal-island-redis-storage.ts
@@ -51,6 +51,7 @@ export class NormalIslandRedisStorage implements NormalIslandStorage {
             createdAt: new Date(Number(islandInfo.createdAt)),
             tags,
             players: new Set(players),
+            ownerId: islandInfo.ownerId,
         };
     }
 

--- a/src/modules/game/game-island-create-service.module.ts
+++ b/src/modules/game/game-island-create-service.module.ts
@@ -4,9 +4,11 @@ import { IslandTagComponentModule } from 'src/modules/island-tags/island-tag-com
 import { IslandComponentModule } from 'src/modules/islands/island-component.module';
 import { NormalIslandStorageComponentModule } from 'src/modules/islands/normal-island-storage-component.module';
 import { TagComponentModule } from 'src/modules/tags/tag-component.module';
+import { UserComponentModule } from 'src/modules/users/users-component.module';
 
 @Module({
     imports: [
+        UserComponentModule,
         NormalIslandStorageComponentModule,
         IslandComponentModule,
         TagComponentModule,

--- a/src/modules/game/game.module.ts
+++ b/src/modules/game/game.module.ts
@@ -34,7 +34,6 @@ import { GameIslandCreateServiceModule } from 'src/modules/game/game-island-crea
         LobyGateway,
         IslandGateway,
         ChatGateway,
-        GameIslandCreateService,
         FriendGateway,
         WsConnectionAuthenticator,
     ],

--- a/src/modules/islands/island.module.ts
+++ b/src/modules/islands/island.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { NormalIslandStorageComponentModule } from 'src/modules/islands/normal-island-storage-component.module';
+import { PlayerStorageComponentModule } from 'src/modules/users/player-storage-component.module';
+import { IslandController } from 'src/presentation/controller/islands/island.controller';
+
+@Module({
+    imports: [NormalIslandStorageComponentModule, PlayerStorageComponentModule],
+    controllers: [IslandController],
+})
+export class IslandModule {}

--- a/src/presentation/controller/islands/island.controller.ts
+++ b/src/presentation/controller/islands/island.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Get, Param, UseFilters, UseGuards } from '@nestjs/common';
+import {
+    ApiBearerAuth,
+    ApiOperation,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
+import { HttpExceptionFilter } from 'src/common/filter/http-exception.filter';
+import { AuthGuard } from 'src/common/guard/auth.guard';
+import { NormalIslandStorageReader } from 'src/domain/components/islands/normal-storage/normal-island-storage-reader';
+import { PlayerStorageReader } from 'src/domain/components/users/player-storage-reader';
+import { GetIslandDetailResponse } from 'src/presentation/dto/island/response/get-island-detail.response';
+
+@ApiTags('islands')
+@ApiResponse({ status: 400, description: '잘못된 요청' })
+@ApiResponse({ status: 401, description: '인증 실패 (토큰 누락 또는 만료)' })
+@ApiBearerAuth()
+@UseFilters(HttpExceptionFilter)
+@UseGuards(AuthGuard)
+@Controller('islands')
+export class IslandController {
+    constructor(
+        private readonly playerStorageReader: PlayerStorageReader,
+        private readonly normalIslandStorageReader: NormalIslandStorageReader,
+    ) {}
+
+    @ApiOperation({ summary: '섬 조회' })
+    @ApiResponse({
+        status: 200,
+        description: '조회 성공',
+        type: GetIslandDetailResponse,
+    })
+    @ApiResponse({ status: 404, description: '존재하지 않는 섬' })
+    @Get(':id')
+    async getIsland(@Param('id') id: string): Promise<GetIslandDetailResponse> {
+        const island = await this.normalIslandStorageReader.readOne(id);
+        const owner = await this.playerStorageReader.readOne(island.ownerId);
+
+        return {
+            coverImage: island.coverImage,
+            description: island.description,
+            id: island.id,
+            maxMembers: island.max,
+            name: island.name,
+            tags: island.tags,
+            owner: {
+                id: owner.id,
+                nickname: owner.nickname,
+            },
+        };
+    }
+}

--- a/src/presentation/dto/island/index.ts
+++ b/src/presentation/dto/island/index.ts
@@ -1,3 +1,4 @@
 export * from './request/get-live-island-list.request';
 
 export * from './response/get-live-island-list.response';
+export * from './response/get-island-detail.response';

--- a/src/presentation/dto/island/response/get-island-detail.response.ts
+++ b/src/presentation/dto/island/response/get-island-detail.response.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetIslandDetailResponse {
+    @ApiProperty({ example: 'uuid' })
+    readonly id: string;
+
+    @ApiProperty({ example: '섬입니다' })
+    readonly name: string;
+
+    @ApiProperty({ example: '설명입니다' })
+    readonly description: string;
+
+    @ApiProperty({ example: 5 })
+    readonly maxMembers: number;
+
+    @ApiProperty({ example: 'https://image.com' })
+    readonly coverImage: string;
+
+    @ApiProperty({ example: ['자유', '수다', '친목'] })
+    readonly tags: string[];
+
+    @ApiProperty()
+    readonly owner: { id: string; nickname: string };
+}

--- a/test/e2e/island-gateway.e2e-spec.ts
+++ b/test/e2e/island-gateway.e2e-spec.ts
@@ -66,6 +66,7 @@ describe('IslandGateway (e2e)', () => {
                 players: new Set<string>(),
                 tags: ['자유'],
                 type: IslandTypeEnum.NORMAL,
+                ownerId: v4(),
             };
             await normalIslandStorage.createIsland(island);
 

--- a/test/e2e/island.e2e-spec.ts
+++ b/test/e2e/island.e2e-spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../../src/app.module';
+import { PrismaService } from 'src/infrastructure/prisma/prisma.service';
+import { RedisClientService } from 'src/infrastructure/redis/redis-client.service';
+import Redis from 'ioredis';
+import { NormalIslandStorage } from 'src/domain/interface/storages/normal-island-storage';
+import {
+    generateNormalIslandModel,
+    generatePlayerModel,
+    generateUserEntityV2,
+} from 'test/helper/generators';
+import { login } from 'test/helper/login';
+import { ResponseResult } from 'test/helper/types';
+import { GetIslandDetailResponse } from 'src/presentation/dto/island/response/get-island-detail.response';
+import { PlayerMemoryStorage } from 'src/infrastructure/storages/player-memory-storage';
+
+describe('AppController (e2e)', () => {
+    let app: INestApplication;
+    let db: PrismaService;
+    let redis: Redis;
+    let normalIslandStorage: NormalIslandStorage;
+    let playerMemoryStrorage: PlayerMemoryStorage;
+
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        await app.init();
+
+        db = app.get<PrismaService>(PrismaService);
+        redis = app.get<RedisClientService>(RedisClientService).getClient();
+        normalIslandStorage = app.get<NormalIslandStorage>(NormalIslandStorage);
+        playerMemoryStrorage =
+            app.get<PlayerMemoryStorage>(PlayerMemoryStorage);
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    afterEach(async () => {
+        await redis.flushall();
+        await db.island.deleteMany();
+        await db.user.deleteMany();
+    });
+
+    describe('GET /islands/:id - 섬 상세 조회', () => {
+        const user = generateUserEntityV2();
+        const island = generateNormalIslandModel({ ownerId: user.id });
+        const player = generatePlayerModel({
+            id: user.id,
+            nickname: user.nickname,
+            roomId: island.id,
+        });
+
+        beforeEach(async () => {
+            await db.user.create({ data: user });
+            await normalIslandStorage.createIsland(island);
+            playerMemoryStrorage.addPlayer(player);
+        });
+
+        it('섬 조회 정상 동작', async () => {
+            const { accessToken } = await login(app);
+
+            const response = (await request(app.getHttpServer())
+                .get(`/islands/${island.id}`)
+                .set(
+                    'Authorization',
+                    accessToken,
+                )) as ResponseResult<GetIslandDetailResponse>;
+            const { body, status } = response;
+
+            const expected: GetIslandDetailResponse = {
+                id: island.id,
+                name: island.name,
+                description: island.description,
+                coverImage: island.coverImage,
+                maxMembers: island.max,
+                tags: island.tags,
+                owner: {
+                    id: island.ownerId,
+                    nickname: user.nickname,
+                },
+            };
+
+            expect(status).toBe(200);
+            expect(body).toEqual(expected);
+        });
+    });
+});

--- a/test/helper/generators.ts
+++ b/test/helper/generators.ts
@@ -197,5 +197,6 @@ export const generateNormalIslandModel = (
         description: partial?.description || 'Island description',
         name: partial?.name || 'Island name',
         tags: partial?.tags || ['tag1', 'tag2'],
+        ownerId: partial?.ownerId || v4(),
     };
 };

--- a/test/unit/services/game-island-create.service.unit-spec.ts
+++ b/test/unit/services/game-island-create.service.unit-spec.ts
@@ -3,7 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import Redis from 'ioredis';
 import { ClsModule } from 'nestjs-cls';
 import { clsOptions } from 'src/configs/cls/cls-config';
-import { IslandPrototype } from 'src/domain/entities/islands/island.entity';
+import { NormalIslandPrototype } from 'src/domain/entities/islands/island.entity';
 import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
 import { DomainException } from 'src/domain/exceptions/exceptions';
 import { TAG_AT_LEAST_ONE_MESSAGE } from 'src/domain/exceptions/message';
@@ -56,7 +56,7 @@ describe('GameIslandService', () => {
         const user = generateUserEntityV2();
         const tag = generateTag('자유');
 
-        const prototype: IslandPrototype = {
+        const prototype: NormalIslandPrototype = {
             maxMembers: 5,
             type: IslandTypeEnum.NORMAL,
             coverImage: 'https://example.com/cover.jpg',

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mmorntype",
-    "version": "1.0.62",
+    "version": "1.0.63",
     "description": "mmorn dto type",
     "typings": "./dist/types/index.d.ts",
     "files": [


### PR DESCRIPTION
## 작업 내용
- 일반 섬 조회 기능 구현.
  - `GET` `/islands/:id`
  - 참여 중인 섬 정보라서 레디스에서만 가져옴.