### PR TITLE
섬 주인 이탈 시 주인 변경 기능 구현

### DIFF
--- a/src/domain/components/islands/deserted-storage/deserted-island-manager.ts
+++ b/src/domain/components/islands/deserted-storage/deserted-island-manager.ts
@@ -92,7 +92,7 @@ export class DesertedIslandManager implements IslandManager {
             );
         }
 
-        return player;
+        return { player };
     }
 
     async removeEmpty(islandId: string): Promise<void> {

--- a/src/domain/components/islands/deserted-storage/deserted-island-manager.ts
+++ b/src/domain/components/islands/deserted-storage/deserted-island-manager.ts
@@ -1,4 +1,5 @@
 import { HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { IslandJoinWriter } from 'src/domain/components/island-join/island-join-writer';
 import { DesertedIslandStorageReader } from 'src/domain/components/islands/deserted-storage/deserted-island-storage-reader';
 import { DesertedIslandStorageWriter } from 'src/domain/components/islands/deserted-storage/deserted-island-storage-writer';
 import { IslandManager } from 'src/domain/components/islands/interface/island-manager';
@@ -9,6 +10,8 @@ import { ISLAND_FULL } from 'src/domain/exceptions/client-use-messag';
 import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
 import { DomainException } from 'src/domain/exceptions/exceptions';
 import { Player } from 'src/domain/models/game/player';
+import { ISLAND_LOCK_KEY } from 'src/infrastructure/redis/key';
+import { RedisTransactionManager } from 'src/infrastructure/redis/redis-transaction-manager';
 
 @Injectable()
 export class DesertedIslandManager implements IslandManager {
@@ -20,6 +23,9 @@ export class DesertedIslandManager implements IslandManager {
         private readonly playerStorageReader: PlayerStorageReader,
         private readonly playerStorageWriter: PlayerStorageWriter,
         private readonly islandWriter: IslandWriter,
+
+        private readonly islandJoinWriter: IslandJoinWriter,
+        private readonly lockManager: RedisTransactionManager,
     ) {}
 
     async canJoin(islandId: string) {
@@ -61,6 +67,32 @@ export class DesertedIslandManager implements IslandManager {
     async left(islandId: string, playerId: string) {
         await this.desertedIslandStorageWriter.removePlayer(islandId, playerId);
         await this.playerStorageWriter.remove(playerId);
+    }
+
+    async handleLeave(player: Player) {
+        const { roomId: islandId } = player;
+
+        const key = ISLAND_LOCK_KEY(islandId);
+        await this.lockManager.transaction(key, [
+            {
+                execute: () => this.left(islandId, player.id),
+                rollback: () => this.join(player),
+            },
+            {
+                execute: () => this.removeEmpty(islandId),
+            },
+        ]);
+
+        try {
+            await this.islandJoinWriter.left(islandId, player.id);
+        } catch (e) {
+            this.logger.error(
+                `섬 참여 데이터 삭제 실패: ${islandId}, playerId: ${player.id}`,
+                e,
+            );
+        }
+
+        return player;
     }
 
     async removeEmpty(islandId: string): Promise<void> {

--- a/src/domain/components/islands/factory/island-manager-factory.ts
+++ b/src/domain/components/islands/factory/island-manager-factory.ts
@@ -21,4 +21,12 @@ export class IslandManagerFactory {
                 throw new Error('Invalid island type');
         }
     }
+
+    getNormalIslandManager(): NormalIslandManager {
+        return this.normalIslandManager;
+    }
+
+    getDesertedIslandManager(): DesertedIslandManager {
+        return this.desertedIslandManager;
+    }
 }

--- a/src/domain/components/islands/interface/island-manager.ts
+++ b/src/domain/components/islands/interface/island-manager.ts
@@ -5,6 +5,8 @@ export interface IslandManager {
     join(player: Player): Promise<void>;
     getActiveUsers(islandId: string, myPlayerId: string): Promise<Player[]>;
     left(islandId: string, playerId: string): Promise<void>;
-    handleLeave(player: Player): Promise<Player>;
+    handleLeave(
+        player: Player,
+    ): Promise<{ player: Player; ownerChanged?: boolean }>;
     removeEmpty(islandId: string): Promise<void>;
 }

--- a/src/domain/components/islands/interface/island-manager.ts
+++ b/src/domain/components/islands/interface/island-manager.ts
@@ -5,5 +5,6 @@ export interface IslandManager {
     join(player: Player): Promise<void>;
     getActiveUsers(islandId: string, myPlayerId: string): Promise<Player[]>;
     left(islandId: string, playerId: string): Promise<void>;
+    handleLeave(player: Player): Promise<Player>;
     removeEmpty(islandId: string): Promise<void>;
 }

--- a/src/domain/components/islands/normal-storage/normal-island-storage-reader.ts
+++ b/src/domain/components/islands/normal-storage/normal-island-storage-reader.ts
@@ -66,6 +66,13 @@ export class NormalIslandStorageReader implements IslandReader {
         return await this.normalIslandStorage.getPlayerIdsByIslandId(islandId);
     }
 
+    async getFirstPlayerExceptSelf(islandId: string, selfId: string) {
+        return await this.normalIslandStorage.getFirstPlayerExceptSelf(
+            islandId,
+            selfId,
+        );
+    }
+
     // logging
     // getStore() {
     //     return this.normalIslandStorage.getIslandStore();

--- a/src/domain/interface/storages/normal-island-storage.ts
+++ b/src/domain/interface/storages/normal-island-storage.ts
@@ -9,6 +9,10 @@ export interface NormalIslandStorage {
     addPlayerToIsland(islandId: string, playerId: string): Promise<void>;
     removePlayer(islandId: string, playerId: string): Promise<void>;
     getPlayerIdsByIslandId(islandId: string): Promise<string[]>;
+    getFirstPlayerExceptSelf(
+        islandId: string,
+        playerId: string,
+    ): Promise<string | null>;
     update(islandId: string, data: NormalIslandUpdateInput): Promise<void>;
     delete(islandId: string): Promise<void>;
 }

--- a/src/domain/services/game/game-island.service.ts
+++ b/src/domain/services/game/game-island.service.ts
@@ -185,31 +185,8 @@ export class GameIslandService {
     }
 
     async handleLeave(player: Player) {
-        const { roomId: islandId, islandType } = player;
-        const manager = this.islandManagerFactory.get(islandType);
-
-        const key = ISLAND_LOCK_KEY(islandId);
-        await this.lockManager.transaction(key, [
-            {
-                execute: () => manager.left(islandId, player.id),
-                rollback: () => manager.join(player),
-            },
-            {
-                execute: () => manager.removeEmpty(islandId),
-                rollback: () => this.createLiveIsland(islandId),
-            },
-        ]);
-
-        try {
-            await this.islandJoinWriter.left(islandId, player.id);
-        } catch (e) {
-            this.logger.error(
-                `섬 참여 데이터 삭제 실패: ${islandId}, playerId: ${player.id}`,
-                e,
-            );
-        }
-
-        return player;
+        const manager = this.islandManagerFactory.get(player.islandType);
+        return await manager.handleLeave(player);
     }
 
     async leave(playerId: string) {

--- a/src/domain/types/island.types.ts
+++ b/src/domain/types/island.types.ts
@@ -23,6 +23,7 @@ export interface NormalIslandUpdateInput {
     name?: string;
     description?: string;
     maxMembers?: number;
+    ownerId?: string;
 }
 
 export interface IslandSummary {

--- a/src/infrastructure/redis/islands/normal-island-redis-storage.ts
+++ b/src/infrastructure/redis/islands/normal-island-redis-storage.ts
@@ -35,7 +35,7 @@ export class NormalIslandRedisStorage implements NormalIslandStorage {
         const [islandInfo, tags, players] = await Promise.all([
             this.redis.getClient().hgetall(islandKey),
             this.redis.getClient().smembers(tagsKey),
-            this.redis.getClient().smembers(playersKey),
+            this.redis.getClient().zrange(playersKey, 0, -1),
         ]);
 
         if (!islandInfo || Object.keys(islandInfo).length === 0) {
@@ -73,29 +73,40 @@ export class NormalIslandRedisStorage implements NormalIslandStorage {
     }
 
     async countPlayer(islandId: string): Promise<number> {
-        return await this.redis.getClient().scard(ISLAND_PLAYERS_KEY(islandId));
+        return await this.redis.getClient().zcard(ISLAND_PLAYERS_KEY(islandId));
     }
 
     async addPlayerToIsland(islandId: string, playerId: string): Promise<void> {
         const key = ISLAND_PLAYERS_KEY(islandId);
-        const players = await this.redis.getClient().smembers(key);
 
-        if (players.length === 0) {
-            await this.redis.getClient().sadd(key, playerId);
-            return;
-        }
-        await this.redis.getClient().sadd(key, playerId);
+        const now = Date.now();
+        await this.redis.getClient().zadd(key, now, playerId);
     }
 
     async removePlayer(islandId: string, playerId: string): Promise<void> {
         const key = ISLAND_PLAYERS_KEY(islandId);
-        await this.redis.getClient().srem(key, playerId);
+
+        await this.redis.getClient().zrem(key, playerId);
     }
 
     async getPlayerIdsByIslandId(islandId: string): Promise<string[]> {
-        return await this.redis
-            .getClient()
-            .smembers(ISLAND_PLAYERS_KEY(islandId));
+        const key = ISLAND_PLAYERS_KEY(islandId);
+
+        const data = await this.redis.getClient().zrange(key, 0, -1);
+        return data;
+    }
+
+    async getFirstPlayerExceptSelf(
+        islandId: string,
+        playerId: string,
+    ): Promise<string | null> {
+        const key = ISLAND_PLAYERS_KEY(islandId);
+
+        // 현재는 인원이 적어서 모두 가져와서 계산함
+        const players = await this.redis.getClient().zrange(key, 0, -1);
+        const fristPlayer = players.find((id) => id !== playerId);
+
+        return fristPlayer || null;
     }
 
     async update(

--- a/src/modules/islands/deserted-island-manager.module.ts
+++ b/src/modules/islands/deserted-island-manager.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { DesertedIslandManager } from 'src/domain/components/islands/deserted-storage/deserted-island-manager';
+import { RedisTransactionManagerModule } from 'src/infrastructure/redis/redis-transaction-manger.module';
 import { IslandJoinComponentModule } from 'src/modules/island-joins/island-join-component.module';
 import { DesertedIslandStorageComponentModule } from 'src/modules/islands/deserted-island-storage-component.module';
 import { IslandComponentModule } from 'src/modules/islands/island-component.module';
@@ -11,6 +12,7 @@ import { PlayerStorageComponentModule } from 'src/modules/users/player-storage-c
         PlayerStorageComponentModule,
         IslandJoinComponentModule,
         IslandComponentModule,
+        RedisTransactionManagerModule,
     ],
     providers: [DesertedIslandManager],
     exports: [DesertedIslandManager],

--- a/src/modules/islands/normal-island-manager.module.ts
+++ b/src/modules/islands/normal-island-manager.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { NormalIslandManager } from 'src/domain/components/islands/normal-storage/normal-island-manager';
+import { RedisTransactionManagerModule } from 'src/infrastructure/redis/redis-transaction-manger.module';
 import { IslandJoinComponentModule } from 'src/modules/island-joins/island-join-component.module';
 import { IslandComponentModule } from 'src/modules/islands/island-component.module';
 import { NormalIslandStorageComponentModule } from 'src/modules/islands/normal-island-storage-component.module';
@@ -11,6 +12,7 @@ import { PlayerStorageComponentModule } from 'src/modules/users/player-storage-c
         PlayerStorageComponentModule,
         IslandJoinComponentModule,
         IslandComponentModule,
+        RedisTransactionManagerModule,
     ],
     providers: [NormalIslandManager],
     exports: [NormalIslandManager],

--- a/src/presentation/gateway/island.gateway.ts
+++ b/src/presentation/gateway/island.gateway.ts
@@ -15,6 +15,7 @@ import { GameService } from 'src/domain/services/game/game.service';
 import { PlayerJoinRequest } from 'src/presentation/dto/game/request/player-join.request';
 import {
     ClientToIsland,
+    IslandSettingsToClient,
     IslandToClient,
 } from 'src/presentation/dto/game/socket/type';
 import { GameIslandService } from 'src/domain/services/game/game-island.service';
@@ -27,7 +28,10 @@ import { WsExceptions } from 'src/presentation/dto/game/socket/known-exception';
 import { PlayerStorageReader } from 'src/domain/components/users/player-storage-reader';
 import { checkAppVersion } from 'test/unit/utils/check-app-version';
 
-type TypedSocket = Socket<ClientToIsland, IslandToClient>;
+type TypedSocket = Socket<
+    ClientToIsland,
+    IslandToClient & IslandSettingsToClient
+>;
 
 @UseFilters(WsExceptionFilter)
 @WebSocketGateway({
@@ -41,7 +45,10 @@ export class IslandGateway
     implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
 {
     @WebSocketServer()
-    private readonly wss: Namespace<ClientToIsland, IslandToClient>;
+    private readonly wss: Namespace<
+        ClientToIsland,
+        IslandToClient & IslandSettingsToClient
+    >;
 
     private readonly logger = new Logger(IslandGateway.name);
 
@@ -122,8 +129,15 @@ export class IslandGateway
         @ConnectedSocket() client: TypedSocket,
         @CurrentUserFromSocket() userId: string,
     ) {
-        const player = await this.gameIslandService.leave(userId);
+        const { player, ownerChanged } =
+            await this.gameIslandService.leave(userId);
         if (player) {
+            if (ownerChanged) {
+                this.wss
+                    .to(player.roomId)
+                    .emit('islandInfoUpdated', { islandId: player.roomId });
+            }
+
             await client.leave(player.roomId);
             client.emit('playerLeftSuccess');
             client.to(player.roomId).emit('playerLeft', { id: player.id });
@@ -227,13 +241,19 @@ export class IslandGateway
 
     async handleDisconnect(client: TypedSocket & { userId: string }) {
         try {
-            const player = await this.gameIslandService.leaveByDisconnect(
-                client.id,
-            );
+            const { player, ownerChanged } =
+                await this.gameIslandService.leaveByDisconnect(client.id);
             const { roomId: islandId } = player;
+
+            if (ownerChanged) {
+                this.wss
+                    .to(player.roomId)
+                    .emit('islandInfoUpdated', { islandId: player.roomId });
+            }
 
             await client.leave(islandId);
             client.to(islandId).emit('playerLeft', { id: player.id });
+
             this.logger.debug(
                 `Cliend id from Island:${player.id} disconnected`,
             );


### PR DESCRIPTION
## 작업 내용
- 주인 이탈 시 가장 먼저 들어온 회원에게 권한 이전.
- 일반 섬의 참여자를 저장하는 `Redis`의 자료구조를 SET에서 ZSET으로 변경.
  - `ZSET`은 `score` 값에 따른 순서를 보장해줘서 최초 입장 플레이어를 간단하게 식별 가능.
- `GameIslandService`에 구현한 `handleLeave`를 각 섬의 `manager` 클래스로 위임.
  - 같은 `handleLeave`인데 내부 구현체만 다른 경우가 발생해서 `manager` 내부로 위임하고 `service`에서는 `factory`로 획득 후 호출.