### PR TITLE
d

### DIFF
--- a/src/infrastructure/redis/islands/deserted-island-redis-storage.ts
+++ b/src/infrastructure/redis/islands/deserted-island-redis-storage.ts
@@ -63,12 +63,7 @@ export class DesertedIslandRedisStorage implements DesertedIslandStorage {
 
     async addPlayerToIsland(islandId: string, playerId: string): Promise<void> {
         const key = ISLAND_PLAYERS_KEY(islandId);
-        const players = await this.redis.getClient().smembers(key);
 
-        if (players.length === 0) {
-            await this.redis.getClient().sadd(key, playerId);
-            return;
-        }
         await this.redis.getClient().sadd(key, playerId);
     }
 


### PR DESCRIPTION
## 작업 내용
### `Service`의 `join`을 `Manager`로 위임 및 트랜잭션 내부 처리 수정
- `GameIslandService`의 `join`에서 실행하던 트랜잭션을 `IslandManager` 내부로 위임.
- `IslandManager`에 위임된 `join`은 내부적으로 두 명령을 실행하는데, 그 두 명령을 쪼개서 따로 롤백처리 하도록 변경.
    ![스크린샷 2025-05-28 오전 4 23 16](https://github.com/user-attachments/assets/ab47b64c-367b-4c6b-96f1-7581d9136b25)
- `IslandManager`의 `handleLeave`도 마찬가지로 `left`를 두 명령으로 쪼개서 따로 롤백하도록 변경.

### 테스트 작성
- 무인도 이탈 - unit
  - 정상 동작
  - 참가인 0명일 때 제거
  - 이탈중 예외 롤백

## 특이 사항
- `join`, `leave` 기능의 트랜잭션이 `manager`로 위임됨에 따라 테스트도 그 쪽으로 옮기고 여기서는 통합만 테스트하도록 변경하자.
