### PR TITLE
친구 관련 쓰기 기능 param 변경 및 간단한 리팩토링

### DIFF
--- a/src/domain/components/friends/friend-checker.ts
+++ b/src/domain/components/friends/friend-checker.ts
@@ -54,14 +54,4 @@ export class FriendChecker {
             throw e;
         }
     }
-
-    async checkUnfriend(userId: string, friendshipId: string) {
-        await this.friendReader.readRequestByIdAndStatus(
-            userId,
-            friendshipId,
-            'ACCEPTED',
-        );
-
-        return;
-    }
 }

--- a/src/domain/components/friends/friend-reader.ts
+++ b/src/domain/components/friends/friend-reader.ts
@@ -6,7 +6,6 @@ import { FriendRepository } from 'src/domain/interface/friend.repository';
 import {
     FriendData,
     FriendRequestDirection,
-    FriendStatus,
     PaginatedFriends,
 } from 'src/domain/types/friend.types';
 
@@ -27,26 +26,6 @@ export class FriendReader {
             limit,
             cursor,
         );
-    }
-
-    async readRequestByIdAndStatus(
-        userId: string,
-        requestId: string,
-        status: FriendStatus,
-    ) {
-        const request = await this.friendRepository.findOneByIdAndStatus(
-            userId,
-            requestId,
-            status,
-        );
-
-        if (!request) {
-            throw new DomainException(
-                DomainExceptionType.FRIEND_REQUEST_NOT_FOUND,
-                HttpStatus.NOT_FOUND,
-                FRIEND_REQUEST_NOT_FOUND_MESSAGE,
-            );
-        }
     }
 
     async readRequestBetweenUsers(firstUserId: string, secondUserId: string) {

--- a/src/domain/components/friends/friend-reader.ts
+++ b/src/domain/components/friends/friend-reader.ts
@@ -49,11 +49,11 @@ export class FriendReader {
         }
     }
 
-    async readRequestBetweenUsers(user1Id: string, user2Id: string) {
+    async readRequestBetweenUsers(firstUserId: string, secondUserId: string) {
         const friendRequest =
             await this.friendRepository.findRequestBetweenUsers(
-                user1Id,
-                user2Id,
+                firstUserId,
+                secondUserId,
             );
 
         if (!friendRequest) {

--- a/src/domain/interface/friend.repository.ts
+++ b/src/domain/interface/friend.repository.ts
@@ -29,11 +29,6 @@ export interface FriendRepository {
     ): Promise<PaginatedFriendRequests>;
     updateStatus(friendshipId: string, status: FriendStatus): Promise<void>;
     updateIsRead(userId: string, isRead?: boolean): Promise<void>;
-    findOneByIdAndStatus(
-        userId: string,
-        requestId: string,
-        stats: FriendStatus,
-    ): Promise<FriendData | null>;
     findFriendshipsWithTargets(
         userId: string,
         targetIds: string[],

--- a/src/domain/services/friends/friends.service.ts
+++ b/src/domain/services/friends/friends.service.ts
@@ -140,10 +140,21 @@ export class FriendsService {
         await this.friendWriter.updateRequestStatus(friendship.id, 'REJECTED');
     }
 
-    async removeFriendship(userId: string, friendshipId: string) {
-        await this.friendChecker.checkUnfriend(userId, friendshipId);
+    async removeFriendship(userId: string, targetId: string) {
+        const friendship = await this.friendReader.readRequestBetweenUsers(
+            userId,
+            targetId,
+        );
 
-        await this.friendWriter.deleteFriendship(friendshipId);
+        if (friendship.status !== 'ACCEPTED') {
+            throw new DomainException(
+                DomainExceptionType.FRIEND_REQUEST_NOT_FOUND,
+                HttpStatus.NOT_FOUND,
+                FRIEND_REQUEST_NOT_FOUND_MESSAGE,
+            );
+        }
+
+        await this.friendWriter.deleteFriendship(friendship.id);
     }
 
     async getFriendshipStatus(

--- a/src/domain/services/friends/friends.service.ts
+++ b/src/domain/services/friends/friends.service.ts
@@ -120,14 +120,24 @@ export class FriendsService {
         await this.friendWriter.updateRequestStatus(friendship.id, 'ACCEPTED');
     }
 
-    async rejectFriend(userId: string, requestId: string): Promise<void> {
-        await this.friendReader.readRequestByIdAndStatus(
+    async rejectFriend(userId: string, targetId: string): Promise<void> {
+        const friendship = await this.friendReader.readRequestBetweenUsers(
             userId,
-            requestId,
-            'PENDING',
+            targetId,
         );
 
-        await this.friendWriter.updateRequestStatus(requestId, 'REJECTED');
+        if (
+            friendship.status !== 'PENDING' ||
+            friendship.receiverId !== userId
+        ) {
+            throw new DomainException(
+                DomainExceptionType.FRIEND_REQUEST_NOT_FOUND,
+                HttpStatus.NOT_FOUND,
+                FRIEND_REQUEST_NOT_FOUND_MESSAGE,
+            );
+        }
+
+        await this.friendWriter.updateRequestStatus(friendship.id, 'REJECTED');
     }
 
     async removeFriendship(userId: string, friendshipId: string) {

--- a/src/domain/services/friends/friends.service.ts
+++ b/src/domain/services/friends/friends.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { FriendWriter } from 'src/domain/components/friends/friend-writer';
 import { FriendChecker } from 'src/domain/components/friends/friend-checker';
 import { FriendEntity } from 'src/domain/entities/friend/friend.entity';
@@ -14,6 +14,7 @@ import { GetFriendsResponse } from 'src/presentation/dto';
 import { DomainException } from 'src/domain/exceptions/exceptions';
 import { DomainExceptionType } from 'src/domain/exceptions/enum/domain-exception-type';
 import { PlayerMemoryStorageManager } from 'src/domain/components/users/player-memory-storage-manager';
+import { FRIEND_REQUEST_NOT_FOUND_MESSAGE } from 'src/domain/exceptions/message';
 
 @Injectable()
 export class FriendsService {
@@ -102,14 +103,21 @@ export class FriendsService {
         return { data: requestList, nextCursor };
     }
 
-    async acceptFriend(userId: string, requestId: string): Promise<void> {
-        await this.friendReader.readRequestByIdAndStatus(
+    async acceptFriend(userId: string, targetId: string): Promise<void> {
+        const friendship = await this.friendReader.readRequestBetweenUsers(
             userId,
-            requestId,
-            'PENDING',
+            targetId,
         );
 
-        await this.friendWriter.updateRequestStatus(requestId, 'ACCEPTED');
+        if (friendship.status !== 'PENDING') {
+            throw new DomainException(
+                DomainExceptionType.FRIEND_REQUEST_NOT_FOUND,
+                HttpStatus.NOT_FOUND,
+                FRIEND_REQUEST_NOT_FOUND_MESSAGE,
+            );
+        }
+
+        await this.friendWriter.updateRequestStatus(friendship.id, 'ACCEPTED');
     }
 
     async rejectFriend(userId: string, requestId: string): Promise<void> {

--- a/src/infrastructure/repositories/friend-prisma.repository.ts
+++ b/src/infrastructure/repositories/friend-prisma.repository.ts
@@ -86,20 +86,20 @@ export class FriendPrismaRepository implements FriendRepository {
     }
 
     async findRequestBetweenUsers(
-        user1Id: string,
-        user2Id: string,
+        firstUserId: string,
+        secondUserId: string,
     ): Promise<FriendData | null> {
         return this.prisma.friendRequest.findFirst({
             where: {
                 OR: [
                     {
-                        senderId: user1Id,
-                        receiverId: user2Id,
+                        senderId: firstUserId,
+                        receiverId: secondUserId,
                         deletedAt: null,
                     },
                     {
-                        senderId: user2Id,
-                        receiverId: user1Id,
+                        senderId: secondUserId,
+                        receiverId: firstUserId,
                         deletedAt: null,
                     },
                 ],

--- a/src/infrastructure/repositories/friend-prisma.repository.ts
+++ b/src/infrastructure/repositories/friend-prisma.repository.ts
@@ -197,37 +197,6 @@ export class FriendPrismaRepository implements FriendRepository {
         return { data: mappedRequests, nextCursor };
     }
 
-    async findOneByIdAndStatus(
-        userId: string,
-        requestId: string,
-        status: FriendStatus,
-    ): Promise<FriendData | null> {
-        return this.prisma.friendRequest.findFirst({
-            where: {
-                OR: [
-                    {
-                        id: requestId,
-                        senderId: userId,
-                        status: status,
-                        deletedAt: null,
-                    },
-                    {
-                        id: requestId,
-                        receiverId: userId,
-                        status: status,
-                        deletedAt: null,
-                    },
-                ],
-            },
-            select: {
-                id: true,
-                senderId: true,
-                receiverId: true,
-                status: true,
-            },
-        });
-    }
-
     async findFriendshipsWithTargets(
         userId: string,
         targetIds: string[],

--- a/src/presentation/controller/friends/friends.controller.ts
+++ b/src/presentation/controller/friends/friends.controller.ts
@@ -98,20 +98,15 @@ export class FriendsController {
     }
 
     @ApiOperation({ summary: '친구 요청 거절' })
-    @ApiParam({
-        name: 'requestId',
-        description: '친구요청 ID(UUID)',
-        example: '1af038aa-ad40-4b49-b484-2491681a813b',
-    })
     @ApiResponse({ status: 204, description: '요청 거절 성공(no content)' })
     @ApiResponse({ status: 404, description: '친구 요청이 존재하지 않음' })
     @HttpCode(HttpStatus.NO_CONTENT)
-    @Patch('requests/:requestId/reject')
+    @Patch('requests/:targetId/reject')
     async rejectFriendRequest(
         @CurrentUser() userId: string,
-        @Param('requestId') requestId: string,
+        @Param('targetId') targetId: string,
     ): Promise<void> {
-        await this.friendsService.rejectFriend(userId, requestId);
+        await this.friendsService.rejectFriend(userId, targetId);
     }
 
     @ApiOperation({ summary: '친구 삭제' })

--- a/src/presentation/controller/friends/friends.controller.ts
+++ b/src/presentation/controller/friends/friends.controller.ts
@@ -86,20 +86,15 @@ export class FriendsController {
     }
 
     @ApiOperation({ summary: '친구 요청 수락' })
-    @ApiParam({
-        name: 'requestId',
-        description: '친구요청 ID(UUID)',
-        example: '1af038aa-ad40-4b49-b484-2491681a813b',
-    })
     @ApiResponse({ status: 204, description: '요청 수락 성공(no content)' })
     @ApiResponse({ status: 404, description: '친구 요청이 존재하지 않음' })
     @HttpCode(HttpStatus.NO_CONTENT)
-    @Patch('requests/:requestId/accept')
+    @Patch('requests/:targetId/accept')
     async acceptFriendRequest(
         @CurrentUser() userId: string,
-        @Param('requestId') requestId: string,
+        @Param('targetId') targetId: string,
     ): Promise<void> {
-        await this.friendsService.acceptFriend(userId, requestId);
+        await this.friendsService.acceptFriend(userId, targetId);
     }
 
     @ApiOperation({ summary: '친구 요청 거절' })

--- a/src/presentation/controller/friends/friends.controller.ts
+++ b/src/presentation/controller/friends/friends.controller.ts
@@ -88,6 +88,11 @@ export class FriendsController {
     @ApiOperation({ summary: '친구 요청 수락' })
     @ApiResponse({ status: 204, description: '요청 수락 성공(no content)' })
     @ApiResponse({ status: 404, description: '친구 요청이 존재하지 않음' })
+    @ApiParam({
+        name: 'targetId',
+        description: '대상 회원 ID(UUID)',
+        example: '1af038aa-ad40-4b49-b484-2491681a813b',
+    })
     @HttpCode(HttpStatus.NO_CONTENT)
     @Patch('requests/:targetId/accept')
     async acceptFriendRequest(
@@ -100,6 +105,11 @@ export class FriendsController {
     @ApiOperation({ summary: '친구 요청 거절' })
     @ApiResponse({ status: 204, description: '요청 거절 성공(no content)' })
     @ApiResponse({ status: 404, description: '친구 요청이 존재하지 않음' })
+    @ApiParam({
+        name: 'targetId',
+        description: '대상 회원 ID(UUID)',
+        example: '1af038aa-ad40-4b49-b484-2491681a813b',
+    })
     @HttpCode(HttpStatus.NO_CONTENT)
     @Patch('requests/:targetId/reject')
     async rejectFriendRequest(
@@ -111,19 +121,19 @@ export class FriendsController {
 
     @ApiOperation({ summary: '친구 삭제' })
     @ApiParam({
-        name: 'friendshipId',
-        description: '친구관계 ID(UUID)',
+        name: 'targetId',
+        description: '대상 회원 ID(UUID)',
         example: '1af038aa-ad40-4b49-b484-2491681a813b',
     })
     @ApiResponse({ status: 204, description: '요청 성공(no content)' })
     @ApiResponse({ status: 404, description: '친구 관계가 존재하지 않음' })
     @HttpCode(HttpStatus.NO_CONTENT)
-    @Delete(':friendshipId')
+    @Delete(':targetId')
     async removeFriend(
         @CurrentUser() userId: string,
-        @Param('friendshipId') friendshipId: string,
+        @Param('targetId') targetId: string,
     ): Promise<void> {
-        await this.friendsService.removeFriendship(userId, friendshipId);
+        await this.friendsService.removeFriendship(userId, targetId);
     }
 
     @ApiOperation({ summary: '친구 여부 확인' })

--- a/test/e2e/friend.e2e-spec.ts
+++ b/test/e2e/friend.e2e-spec.ts
@@ -383,7 +383,7 @@ describe('FriendController (e2e)', () => {
         });
     });
 
-    describe('PATCH /friends/requests/:requestId/reject - 친구 요청 거절', () => {
+    describe('PATCH /friends/requests/:targetId/reject - 친구 요청 거절', () => {
         let currentUser: {
             userId: string;
             accessToken: string;
@@ -399,11 +399,12 @@ describe('FriendController (e2e)', () => {
             const friendRequest = generateFriendship(
                 senderUser.id,
                 currentUser.userId,
+                { status: 'PENDING' },
             );
             await prisma.friendRequest.create({ data: friendRequest });
 
             const response = await request(app.getHttpServer())
-                .patch(`/friends/requests/${friendRequest.id}/reject`)
+                .patch(`/friends/requests/${senderUser.id}/reject`)
                 .set('Authorization', currentUser.accessToken);
 
             expect(response.status).toBe(HttpStatus.NO_CONTENT);

--- a/test/e2e/friend.e2e-spec.ts
+++ b/test/e2e/friend.e2e-spec.ts
@@ -287,7 +287,7 @@ describe('FriendController (e2e)', () => {
         });
     });
 
-    describe('PATCH /friends/requests/:requestId/accept - 친구 요청 수락', () => {
+    describe('PATCH /friends/requests/:targetId/accept - 친구 요청 수락', () => {
         let currentUser: { accessToken: string; userId: string };
         const user = generateUserEntityV2();
 
@@ -300,11 +300,12 @@ describe('FriendController (e2e)', () => {
             const friendRequest = generateFriendship(
                 user.id,
                 currentUser.userId,
+                { status: 'PENDING' },
             );
             await prisma.friendRequest.create({ data: friendRequest });
 
             const response = await request(app.getHttpServer())
-                .patch(`/friends/requests/${friendRequest.id}/accept`)
+                .patch(`/friends/requests/${user.id}/accept`)
                 .set('Authorization', currentUser.accessToken);
 
             const updatedRequest = await prisma.friendRequest.findUnique({

--- a/test/e2e/friend.e2e-spec.ts
+++ b/test/e2e/friend.e2e-spec.ts
@@ -439,7 +439,7 @@ describe('FriendController (e2e)', () => {
             await prisma.friendRequest.create({ data: friend });
 
             const response = await request(app.getHttpServer())
-                .delete(`/friends/${friend.id}`)
+                .delete(`/friends/${user.id}`)
                 .set('Authorization', currentUser.accessToken);
 
             expect(response.status).toBe(HttpStatus.NO_CONTENT);


### PR DESCRIPTION
## Summary

- 친구 관련 write 작업에서 요청 id가 아닌 대상 회원 id 받도록 수정.

## 주요 변경 사항

### 1. `requestId` -> `userId`
- 회원 목록 검색한 상태에서 바로 수락 거절하려면 대상 회원 id를 받는 방법이 좋을듯 해요.
- 다른 경우에도 가장 범용성 좋은 것 같슴다 프론트 개발 시에도 편하고.

### 2. 친구 요청 조회 관련 메서드 재사용
- 요청 상태를 확인할 때 `readRequestBetweenUsers`로 조회해서 애플리케이션 단에서 확인해주면 메서드 하나로도 전부 커버 가능해요.
- 코드량도 적고 흐름 파악도 간단해서 예외 throw 관련 코드도 모두 `service`에서 조회된 친구 요청 `status`로 분기처리했어요.
- 따라서 아래의 구체적인 상황을 표현하는 메서드는 제거됐어요.
  - `FriendChecker` - `readRequestByIdAndStatus`
  - `FriendReader` - `checkUnfriend`
  - `FriendRepository` - `findOneByIdAndStatus`