### PR TITLE
소유 중 아이템 조회 기능 구현

### DIFF
--- a/prisma/migrations/20250530204358_create_equipped_item_table/migration.sql
+++ b/prisma/migrations/20250530204358_create_equipped_item_table/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "equipped_item" (
+    "user_id" UUID NOT NULL,
+    "item_id" UUID NOT NULL,
+    "slot" SMALLINT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "equipped_item_pkey" PRIMARY KEY ("user_id","slot")
+);
+
+-- CreateIndex
+CREATE INDEX "equipped_item_item_id_idx" ON "equipped_item"("item_id");

--- a/prisma/migrations/20250531171911_add_product_type_col_to_product/migration.sql
+++ b/prisma/migrations/20250531171911_add_product_type_col_to_product/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "product" ADD COLUMN     "productType" SMALLINT NOT NULL DEFAULT 0;

--- a/prisma/migrations/20250531171951_remove_default_to_product_type/migration.sql
+++ b/prisma/migrations/20250531171951_remove_default_to_product_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "product" ALTER COLUMN "productType" DROP DEFAULT;

--- a/prisma/migrations/20250531173614_add_item_type_col_to_item/migration.sql
+++ b/prisma/migrations/20250531173614_add_item_type_col_to_item/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `productType` on the `product` table. All the data in the column will be lost.
+  - Added the required column `product_type` to the `product` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "item" ADD COLUMN     "item_type" SMALLINT NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "product"
+ADD COLUMN "product_type" SMALLINT;
+
+-- Set Data
+UPDATE "product"
+SET "product_type" = "productType";
+
+-- Set NOT NULL
+ALTER TABLE "product"
+ALTER COLUMN "product_type" SET NOT NULL;
+
+
+-- Drop col
+ALTER TABLE "product"
+DROP COLUMN "productType";

--- a/prisma/migrations/20250531202242_add_image_to_item/migration.sql
+++ b/prisma/migrations/20250531202242_add_image_to_item/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - Added the required column `image` to the `item` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "item" ADD COLUMN "image" TEXT;
+
+-- Product에서 같은 이름의 상품 이미지 가져오기, 현재 단일 상품 뿐
+UPDATE "item"
+SET "image" = "product"."cover_image"
+FROM "product"
+WHERE "product"."name" = "item"."name";
+
+ALTER TABLE "item"
+ALTER COLUMN "image" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -161,6 +161,7 @@ model Item {
   itemType    Int      @default(0) @map("item_type") @db.SmallInt
   key         String   @db.VarChar(50)
   grade       Int      @default(0) @db.SmallInt
+  image       String
   createdAt   DateTime @map("created_at")
 
   products       Product[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -158,6 +158,7 @@ model Item {
   name        String   @db.VarChar(50)
   description String   @db.VarChar(200)
   type        String   @db.VarChar(50)
+  itemType    Int      @default(0) @map("item_type") @db.SmallInt
   key         String   @db.VarChar(50)
   grade       Int      @default(0) @db.SmallInt
   createdAt   DateTime @map("created_at")
@@ -174,6 +175,7 @@ model Product {
   name        String    @db.VarChar(50)
   description String    @db.VarChar(200)
   price       Int
+  productType Int       @map("product_type") @db.SmallInt
   coverImage  String    @map("cover_image")
   itemId      String    @map("item_id") @db.Uuid
   createdAt   DateTime  @map("created_at")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   goldTransactions       GoldTransaction[]
   userOwnedItems         UserOwnedItem[]
   islands                Island[]
+  equippedItems          EquippedItem[]
 
   @@unique([tag, deletedAt])
   @@unique([email, deletedAt])
@@ -163,6 +164,7 @@ model Item {
 
   products       Product[]
   userOwnedItems UserOwnedItem[]
+  equippedItems  EquippedItem[]
 
   @@map("item")
 }
@@ -241,4 +243,19 @@ model UserOwnedItem {
   @@index([userId])
   @@index([itemId])
   @@map("user_owned_item")
+}
+
+model EquippedItem {
+  userId    String   @map("user_id") @db.Uuid
+  itemId    String   @map("item_id") @db.Uuid
+  slot      Int      @db.SmallInt
+  createdAt DateTime @map("created_at")
+  updatedAt DateTime @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id])
+  item Item @relation(fields: [itemId], references: [id])
+
+  @@id([userId, slot])
+  @@index([itemId])
+  @@map("equipped_item")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,7 @@ import { LoaderModule } from 'src/modules/loaders/loader.module';
 import { RedisModule } from 'src/infrastructure/redis/redis.module';
 import { validationSchema } from 'src/env-validation';
 import { IslandModule } from 'src/modules/islands/island.module';
+import { ItemModule } from 'src/modules/items/item.module';
 
 @Module({
     imports: [
@@ -41,6 +42,7 @@ import { IslandModule } from 'src/modules/islands/island.module';
         FileModule,
         TagModule,
         IslandModule,
+        ItemModule,
 
         LoaderModule,
     ],

--- a/src/domain/components/products/product-reader.ts
+++ b/src/domain/components/products/product-reader.ts
@@ -3,6 +3,8 @@ import { ProductRepository } from 'src/domain/interface/product.repository';
 import {
     ProductOrder,
     ProductOrderBy,
+    ProductType,
+    ProductTypeEnum,
     Sort,
 } from 'src/domain/types/product.types';
 
@@ -15,7 +17,7 @@ export class ProductReader {
 
     async read(
         userId: string,
-        type: string,
+        type: ProductType,
         order: ProductOrder,
         page: number,
         limit: number,
@@ -40,7 +42,7 @@ export class ProductReader {
 
         return await this.productRepository.findByCategory(
             userId,
-            type,
+            ProductTypeEnum[type],
             page,
             limit,
             orderBy,

--- a/src/domain/components/user-owned-items/user-owned-item-reader.ts
+++ b/src/domain/components/user-owned-items/user-owned-item-reader.ts
@@ -1,0 +1,24 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { UserOwnedItemRepository } from 'src/domain/interface/user-owned-item.repository';
+import {
+    ItemGrade,
+    ItemGradeEnum,
+    ItemType,
+    ItemTypeEnum,
+} from 'src/domain/types/item.types';
+
+@Injectable()
+export class UserOwnedItemReader {
+    constructor(
+        @Inject(UserOwnedItemRepository)
+        private readonly userOwnedItemRepository: UserOwnedItemRepository,
+    ) {}
+
+    async readAll(userId: string, type: ItemType, grade: ItemGrade) {
+        return await this.userOwnedItemRepository.findAllByTypeAndGrade(
+            userId,
+            ItemTypeEnum[type],
+            ItemGradeEnum[grade],
+        );
+    }
+}

--- a/src/domain/entities/item/item.entity.ts
+++ b/src/domain/entities/item/item.entity.ts
@@ -1,30 +1,33 @@
+import { ItemTypeEnum } from 'src/domain/types/item.types';
+
+export interface ItemPrototype {
+    readonly name: string;
+    readonly description: string;
+    readonly type: string;
+    readonly itemType: ItemTypeEnum;
+    readonly key: string;
+    readonly grade: number;
+}
+
 export class ItemEntity {
     constructor(
         readonly id: string,
         readonly name: string,
         readonly description: string,
         readonly type: string,
+        readonly itemType: ItemTypeEnum,
         readonly key: string,
         readonly grade: number,
         readonly createdAt: Date,
     ) {}
 
-    static create(
-        proto: {
-            name: string;
-            description: string;
-            type: string;
-            key: string;
-            grade: number;
-        },
-        idGen: () => string,
-        stdDate: Date,
-    ) {
+    static create(proto: ItemPrototype, idGen: () => string, stdDate: Date) {
         return new ItemEntity(
             idGen(),
             proto.name,
             proto.description,
             proto.type,
+            proto.itemType,
             proto.key,
             proto.grade,
             stdDate,

--- a/src/domain/entities/item/item.entity.ts
+++ b/src/domain/entities/item/item.entity.ts
@@ -7,6 +7,7 @@ export interface ItemPrototype {
     readonly itemType: ItemTypeEnum;
     readonly key: string;
     readonly grade: number;
+    readonly image: string;
 }
 
 export class ItemEntity {
@@ -18,6 +19,7 @@ export class ItemEntity {
         readonly itemType: ItemTypeEnum,
         readonly key: string,
         readonly grade: number,
+        readonly image: string,
         readonly createdAt: Date,
     ) {}
 
@@ -30,6 +32,7 @@ export class ItemEntity {
             proto.itemType,
             proto.key,
             proto.grade,
+            proto.image,
             stdDate,
         );
     }

--- a/src/domain/entities/product/product.entity.ts
+++ b/src/domain/entities/product/product.entity.ts
@@ -1,3 +1,14 @@
+import { ProductTypeEnum } from 'src/domain/types/product.types';
+
+interface ProductPrototype {
+    readonly ItemId: string;
+    readonly name: string;
+    readonly description: string;
+    readonly price: number;
+    readonly coverImage: string;
+    readonly productType: ProductTypeEnum;
+}
+
 export class ProducEntity {
     constructor(
         readonly id: string,
@@ -6,21 +17,12 @@ export class ProducEntity {
         readonly description: string,
         readonly price: number,
         readonly coverImage: string,
+        readonly productType: ProductTypeEnum,
         readonly createdAt: Date,
         readonly updatedAt: Date,
     ) {}
 
-    static create(
-        proto: {
-            ItemId: string;
-            name: string;
-            description: string;
-            price: number;
-            coverImage: string;
-        },
-        idGen: () => string,
-        stdDate: Date,
-    ) {
+    static create(proto: ProductPrototype, idGen: () => string, stdDate: Date) {
         return new ProducEntity(
             idGen(),
             proto.ItemId,
@@ -28,6 +30,7 @@ export class ProducEntity {
             proto.description,
             proto.price,
             proto.coverImage,
+            proto.productType,
             stdDate,
             stdDate,
         );

--- a/src/domain/interface/product.repository.ts
+++ b/src/domain/interface/product.repository.ts
@@ -3,12 +3,13 @@ import {
     Product,
     Sort,
     ProductForPurchase,
+    ProductTypeEnum,
 } from 'src/domain/types/product.types';
 
 export interface ProductRepository {
     findByCategory(
         userId: string,
-        type: string,
+        type: ProductTypeEnum,
         page: number,
         limit: number,
         orderBy: ProductOrderBy,

--- a/src/domain/interface/user-owned-item.repository.ts
+++ b/src/domain/interface/user-owned-item.repository.ts
@@ -1,6 +1,12 @@
 import { UserOwnedItemEntity } from 'src/domain/entities/user-owned-items/user-owned-item.entity';
+import { Item, ItemGradeEnum, ItemTypeEnum } from 'src/domain/types/item.types';
 
 export interface UserOwnedItemRepository {
+    findAllByTypeAndGrade(
+        userId: string,
+        itemType: ItemTypeEnum,
+        grade: ItemGradeEnum,
+    ): Promise<Item[]>;
     save(data: UserOwnedItemEntity): Promise<void>;
     saveMany(data: UserOwnedItemEntity[]): Promise<void>;
 }

--- a/src/domain/types/gold-transaction.types.ts
+++ b/src/domain/types/gold-transaction.types.ts
@@ -8,15 +8,4 @@ export enum GoldTransactionTypeEnum {
 
 export const convertNumberToGoldTransactionType = (
     type: number,
-): GoldTransactionType => {
-    switch (type) {
-        case 0:
-            return 'PAYMENT';
-        case 1:
-            return 'PURCHASE';
-        case 2:
-            return 'REFUND';
-        default:
-            return 'PAYMENT';
-    }
-};
+): GoldTransactionType => goldTransactionTypes[type];

--- a/src/domain/types/item.types.ts
+++ b/src/domain/types/item.types.ts
@@ -7,20 +7,8 @@ export enum ItemGradeEnum {
     EPIC,
 }
 
-export const convertNumberToGrade = (grade: number): ItemGrade => {
-    switch (grade) {
-        case 0:
-            return 'NORMAL';
-        case 1:
-            return 'RARE';
-        case 2:
-            return 'UNIQUE';
-        case 3:
-            return 'EPIC';
-        default:
-            return 'NORMAL';
-    }
-};
+export const convertNumberToGrade = (grade: number): ItemGrade =>
+    itemGrades[grade];
 
 export const itemTypes = ['AURA', 'SPEECH_BUBBLE'] as const;
 export type ItemType = (typeof itemTypes)[number];

--- a/src/domain/types/item.types.ts
+++ b/src/domain/types/item.types.ts
@@ -7,7 +7,7 @@ export enum ItemGradeEnum {
     EPIC,
 }
 
-export const convertNumberToGrade = (grade: number): ItemGrade =>
+export const convertNumberToItemGrade = (grade: number): ItemGrade =>
     itemGrades[grade];
 
 export const itemTypes = ['AURA', 'SPEECH_BUBBLE'] as const;
@@ -17,7 +17,7 @@ export enum ItemTypeEnum {
     SPEECH_BUBBLE,
 }
 
-export const convertNumberToType = (type: number) => {
+export const convertNumberToItemType = (type: number) => {
     return itemTypes[type];
 };
 
@@ -27,5 +27,5 @@ export interface Item {
     readonly description: string;
     readonly type: ItemType;
     readonly key: string;
-    readonly grade: string;
+    readonly grade: ItemGrade;
 }

--- a/src/domain/types/item.types.ts
+++ b/src/domain/types/item.types.ts
@@ -28,4 +28,5 @@ export interface Item {
     readonly type: ItemType;
     readonly key: string;
     readonly grade: ItemGrade;
+    readonly image: string;
 }

--- a/src/domain/types/item.types.ts
+++ b/src/domain/types/item.types.ts
@@ -21,3 +21,23 @@ export const convertNumberToGrade = (grade: number): ItemGrade => {
             return 'NORMAL';
     }
 };
+
+export const itemTypes = ['AURA', 'SPEECH_BUBBLE'] as const;
+export type ItemType = (typeof itemTypes)[number];
+export enum ItemTypeEnum {
+    AURA,
+    SPEECH_BUBBLE,
+}
+
+export const convertNumberToType = (type: number) => {
+    return itemTypes[type];
+};
+
+export interface Item {
+    readonly id: string;
+    readonly name: string;
+    readonly description: string;
+    readonly type: ItemType;
+    readonly key: string;
+    readonly grade: string;
+}

--- a/src/domain/types/product.types.ts
+++ b/src/domain/types/product.types.ts
@@ -21,9 +21,13 @@ export interface Product {
     readonly purchasedStatus: PurchasedStatus;
 }
 
-export enum ProductType {
-    AURA = 'aura',
+export const productTypes = ['AURA', 'SPEECH_BUBBLE'] as const;
+export type ProductType = (typeof productTypes)[number];
+export enum ProductTypeEnum {
+    AURA,
+    SPEECH_BUBBLE,
 }
+export const convertNumberToProductType = (type: number) => productTypes[type];
 
 export enum ProductOrder {
     LATEST = 'latest',

--- a/src/domain/types/purchase.types.ts
+++ b/src/domain/types/purchase.types.ts
@@ -5,15 +5,5 @@ export enum PurchaseStatusEnum {
     REFUND,
 }
 
-export const convertNumberToPurchaseStatus = (
-    status: number,
-): PurchaseStatus => {
-    switch (status) {
-        case 0:
-            return 'COMPLETE';
-        case 1:
-            return 'REFUND';
-        default:
-            return 'COMPLETE';
-    }
-};
+export const convertNumberToPurchaseStatus = (status: number): PurchaseStatus =>
+    purchaseStatus[status];

--- a/src/infrastructure/repositories/product-prisma.repository.ts
+++ b/src/infrastructure/repositories/product-prisma.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ProductRepository } from 'src/domain/interface/product.repository';
-import { convertNumberToGrade } from 'src/domain/types/item.types';
+import { convertNumberToItemGrade } from 'src/domain/types/item.types';
 import {
     convertNumberToProductType,
     Product,
@@ -67,7 +67,7 @@ export class ProductPrismaRepository implements ProductRepository {
                 key: item.key,
                 name: item.name,
                 type: convertNumberToProductType(item.itemType),
-                grade: convertNumberToGrade(item.grade),
+                grade: convertNumberToItemGrade(item.grade),
                 purchasedStatus: purchases.length > 0 ? 'PURCHASED' : 'NONE',
             };
         });

--- a/src/infrastructure/repositories/product-prisma.repository.ts
+++ b/src/infrastructure/repositories/product-prisma.repository.ts
@@ -2,9 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { ProductRepository } from 'src/domain/interface/product.repository';
 import { convertNumberToGrade } from 'src/domain/types/item.types';
 import {
+    convertNumberToProductType,
     Product,
     ProductForPurchase,
     ProductOrderBy,
+    ProductTypeEnum,
     Sort,
 } from 'src/domain/types/product.types';
 import { PrismaService } from 'src/infrastructure/prisma/prisma.service';
@@ -15,7 +17,7 @@ export class ProductPrismaRepository implements ProductRepository {
 
     async findByCategory(
         userId: string,
-        type: string,
+        type: ProductTypeEnum,
         page: number,
         limit: number,
         orderBy: ProductOrderBy,
@@ -30,7 +32,7 @@ export class ProductPrismaRepository implements ProductRepository {
                     select: {
                         name: true,
                         description: true,
-                        type: true,
+                        itemType: true,
                         key: true,
                         grade: true,
                     },
@@ -50,17 +52,21 @@ export class ProductPrismaRepository implements ProductRepository {
                 [orderBy]: sort,
             },
             where: {
-                item: {
-                    type,
-                },
+                productType: type,
             },
         });
 
         return products.map((product) => {
-            const { item, purchases, ...rest } = product;
+            const { item, purchases, id, price, coverImage } = product;
+
             return {
-                ...rest,
-                ...item,
+                id,
+                price,
+                coverImage,
+                description: item.description,
+                key: item.key,
+                name: item.name,
+                type: convertNumberToProductType(item.itemType),
                 grade: convertNumberToGrade(item.grade),
                 purchasedStatus: purchases.length > 0 ? 'PURCHASED' : 'NONE',
             };

--- a/src/infrastructure/repositories/user-owned-item-prisma.repository.ts
+++ b/src/infrastructure/repositories/user-owned-item-prisma.repository.ts
@@ -32,6 +32,7 @@ export class UserOwnedItemPrismaRepository implements UserOwnedItemRepository {
                         itemType: true,
                         key: true,
                         grade: true,
+                        image: true,
                     },
                 },
             },

--- a/src/infrastructure/repositories/user-owned-item-prisma.repository.ts
+++ b/src/infrastructure/repositories/user-owned-item-prisma.repository.ts
@@ -3,12 +3,61 @@ import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-pr
 import { Injectable } from '@nestjs/common';
 import { UserOwnedItemEntity } from 'src/domain/entities/user-owned-items/user-owned-item.entity';
 import { UserOwnedItemRepository } from 'src/domain/interface/user-owned-item.repository';
+import {
+    ItemTypeEnum,
+    ItemGradeEnum,
+    Item,
+    convertNumberToItemGrade,
+    convertNumberToItemType,
+} from 'src/domain/types/item.types';
 
 @Injectable()
 export class UserOwnedItemPrismaRepository implements UserOwnedItemRepository {
     constructor(
         private readonly txHost: TransactionHost<TransactionalAdapterPrisma>,
     ) {}
+
+    async findAllByTypeAndGrade(
+        userId: string,
+        itemType: ItemTypeEnum,
+        grade: ItemGradeEnum,
+    ): Promise<Item[]> {
+        const result = await this.txHost.tx.userOwnedItem.findMany({
+            select: {
+                item: {
+                    select: {
+                        id: true,
+                        name: true,
+                        description: true,
+                        itemType: true,
+                        key: true,
+                        grade: true,
+                    },
+                },
+            },
+            where: {
+                userId,
+                item: {
+                    grade,
+                    itemType,
+                },
+            },
+            orderBy: {
+                item: {
+                    name: 'asc',
+                },
+            },
+        });
+
+        return result.map((item) => {
+            const { itemType, grade, ...itemData } = item.item;
+            return {
+                ...itemData,
+                type: convertNumberToItemType(itemType),
+                grade: convertNumberToItemGrade(grade),
+            };
+        });
+    }
 
     async save(data: UserOwnedItemEntity): Promise<void> {
         await this.txHost.tx.userOwnedItem.create({ data });

--- a/src/modules/items/item.module.ts
+++ b/src/modules/items/item.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserOwnedItemComponentModule } from 'src/modules/user-owned-items/user-owned-item-component.module';
+import { ItemController } from 'src/presentation/controller/items/item.controller';
+
+@Module({
+    imports: [UserOwnedItemComponentModule],
+    controllers: [ItemController],
+})
+export class ItemModule {}

--- a/src/modules/user-owned-items/user-owned-item-component.module.ts
+++ b/src/modules/user-owned-items/user-owned-item-component.module.ts
@@ -1,16 +1,18 @@
 import { Module } from '@nestjs/common';
+import { UserOwnedItemReader } from 'src/domain/components/user-owned-items/user-owned-item-reader';
 import { UserOwnedItemWriter } from 'src/domain/components/user-owned-items/user-owned-item-writer';
 import { UserOwnedItemRepository } from 'src/domain/interface/user-owned-item.repository';
 import { UserOwnedItemPrismaRepository } from 'src/infrastructure/repositories/user-owned-item-prisma.repository';
 
 @Module({
     providers: [
+        UserOwnedItemReader,
         UserOwnedItemWriter,
         {
             provide: UserOwnedItemRepository,
             useClass: UserOwnedItemPrismaRepository,
         },
     ],
-    exports: [UserOwnedItemWriter],
+    exports: [UserOwnedItemReader, UserOwnedItemWriter],
 })
 export class UserOwnedItemComponentModule {}

--- a/src/presentation/controller/items/item.controller.ts
+++ b/src/presentation/controller/items/item.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Query, UseFilters, UseGuards } from '@nestjs/common';
+import {
+    ApiBearerAuth,
+    ApiOperation,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
+import { CurrentUser } from 'src/common/decorator/current-user.decorator';
+import { HttpExceptionFilter } from 'src/common/filter/http-exception.filter';
+import { AuthGuard } from 'src/common/guard/auth.guard';
+import { UserOwnedItemReader } from 'src/domain/components/user-owned-items/user-owned-item-reader';
+import { GetOwnedItemListRequest } from 'src/presentation/dto/items/request/get-owned-item-list.request';
+import { GetOwnedItemListResponse } from 'src/presentation/dto/items/response/get-owned-item-list.response';
+
+@ApiTags('items')
+@ApiResponse({ status: 400, description: '잘못된 요청' })
+@ApiResponse({ status: 401, description: '인증 실패 (토큰 누락 또는 만료)' })
+@ApiBearerAuth()
+@UseFilters(HttpExceptionFilter)
+@UseGuards(AuthGuard)
+@Controller('items')
+export class ItemController {
+    constructor(private readonly userOwnedItemReader: UserOwnedItemReader) {}
+
+    @ApiOperation({
+        summary: '소유하고 있는 모든 아이템 조회 (타입, 등급 별)',
+    })
+    @ApiResponse({
+        status: 200,
+        description: '조회 성공',
+        type: GetOwnedItemListResponse,
+    })
+    @Get('owned')
+    async getAllOwnedItems(
+        @CurrentUser() userId: string,
+        @Query() dto: GetOwnedItemListRequest,
+    ): Promise<GetOwnedItemListResponse> {
+        const { type, grade } = dto;
+        const items = await this.userOwnedItemReader.readAll(
+            userId,
+            type,
+            grade,
+        );
+
+        return { items };
+    }
+}

--- a/src/presentation/dto/index.ts
+++ b/src/presentation/dto/index.ts
@@ -8,3 +8,4 @@ export * from './purchases';
 export * from './island';
 export * from './files';
 export * from './tags';
+export * from './items';

--- a/src/presentation/dto/items/index.ts
+++ b/src/presentation/dto/items/index.ts
@@ -1,0 +1,2 @@
+export * from './request/get-owned-item-list.request';
+export * from './response/get-owned-item-list.response';

--- a/src/presentation/dto/items/request/get-owned-item-list.request.ts
+++ b/src/presentation/dto/items/request/get-owned-item-list.request.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+    ItemGrade,
+    itemGrades,
+    ItemType,
+    itemTypes,
+} from '../../../../domain/types/item.types';
+import { IsEnum } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class GetOwnedItemListRequest {
+    @ApiProperty({
+        enum: itemTypes,
+        example: 'AURA',
+        description: '아이템 타입',
+    })
+    @IsEnum(itemTypes)
+    @Transform(({ value }) => String(value).toUpperCase())
+    readonly type: ItemType;
+
+    @ApiProperty({
+        enum: itemGrades,
+        example: 'RARE',
+        description: '아이템 등급',
+    })
+    @IsEnum(itemGrades)
+    @Transform(({ value }) => String(value).toUpperCase())
+    readonly grade: ItemGrade;
+}

--- a/src/presentation/dto/items/response/get-owned-item-list.response.ts
+++ b/src/presentation/dto/items/response/get-owned-item-list.response.ts
@@ -38,6 +38,12 @@ class Item {
         description: '아이템 등급 (예: NORMAL, RARE 등)',
     })
     readonly grade: ItemGrade;
+
+    @ApiProperty({
+        example: 'https://cdn.image.com',
+        description: '아이템 이미지',
+    })
+    readonly image: string;
 }
 
 export class GetOwnedItemListResponse {

--- a/src/presentation/dto/items/response/get-owned-item-list.response.ts
+++ b/src/presentation/dto/items/response/get-owned-item-list.response.ts
@@ -1,0 +1,49 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+    ItemGrade,
+    itemGrades,
+    ItemType,
+    itemTypes,
+} from '../../../../domain/types/item.types';
+
+class Item {
+    @ApiProperty({ example: 'uuid', description: '아이템 고유 ID' })
+    readonly id: string;
+
+    @ApiProperty({ example: '토마토 오라', description: '아이템 이름' })
+    readonly name: string;
+
+    @ApiProperty({
+        example: '토마토 색의 오라.',
+        description: '아이템 설명',
+    })
+    readonly description: string;
+
+    @ApiProperty({
+        enum: itemTypes,
+        example: 'AURA',
+        description: '아이템 타입 (예: AURA, SPEECH_BUBBLE 등)',
+    })
+    readonly type: ItemType;
+
+    @ApiProperty({
+        example: 'tomato_aura',
+        description: '아이템 고유 키값',
+    })
+    readonly key: string;
+
+    @ApiProperty({
+        enum: itemGrades,
+        example: 'RARE',
+        description: '아이템 등급 (예: NORMAL, RARE 등)',
+    })
+    readonly grade: ItemGrade;
+}
+
+export class GetOwnedItemListResponse {
+    @ApiProperty({
+        type: [Item],
+        description: '플레이어가 보유한 아이템 목록',
+    })
+    readonly items: Item[];
+}

--- a/src/presentation/dto/product/request/get-product-list.request.ts
+++ b/src/presentation/dto/product/request/get-product-list.request.ts
@@ -1,11 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsInt, Max, Min } from 'class-validator';
-import { ProductType, ProductOrder } from '../../shared';
-import { Type } from 'class-transformer';
+import { ProductOrder } from '../../shared';
+import { Transform, Type } from 'class-transformer';
+import { ProductType, productTypes } from 'src/domain/types/product.types';
 
 export class GetProductListRequest {
-    @ApiProperty({ example: ProductType.AURA, enum: ProductType })
-    @IsEnum(ProductType)
+    @ApiProperty({ example: productTypes[0], enum: productTypes })
+    @Transform(({ value }) => {
+        if (typeof value === 'string') {
+            return value.toUpperCase();
+        }
+    })
+    @IsEnum(productTypes)
     readonly type: ProductType;
 
     @ApiProperty({ enum: ProductOrder })

--- a/src/presentation/dto/shared.ts
+++ b/src/presentation/dto/shared.ts
@@ -3,11 +3,6 @@ export type Provider = 'GOOGLE' | 'KAKAO' | 'NAVER';
 export type FrinedStatus = 'ACCEPTED' | 'PENDING' | 'REJECTED';
 export type FriendRequestStatus = 'ACCEPTED' | 'SENT' | 'RECEIVED' | 'NONE';
 
-export enum ProductType {
-    AURA = 'aura',
-    SPEACH_BUBBLE = 'speach-bubble',
-}
-
 export enum ProductOrder {
     LATEST = 'latest',
     PRICIEST = 'priciest',

--- a/test/e2e/item-input-validation.e2e-spec.ts
+++ b/test/e2e/item-input-validation.e2e-spec.ts
@@ -1,0 +1,86 @@
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from 'src/app.module';
+import { login } from 'test/helper/login';
+
+describe('Items Input Validation (e2e)', () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        await app.init();
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    describe('GET /items/owned 입력 값 검증', () => {
+        it('존재하지 않는 타입을 전달하면 예외가 발생한다.', async () => {
+            const { accessToken } = await login(app);
+
+            const query = {
+                type: 'INVALID_TYPE',
+                grade: 'NORMAL',
+            };
+
+            const response = await request(app.getHttpServer())
+                .get('/items/owned')
+                .query(query)
+                .set('Authorization', accessToken);
+
+            expect(response.status).toEqual(400);
+        });
+
+        it('존재하지 않는 등급을 전달하면 예외가 발생한다.', async () => {
+            const { accessToken } = await login(app);
+
+            const query = {
+                type: 'AURA',
+                grade: 'INVALID_GRADE',
+            };
+
+            const response = await request(app.getHttpServer())
+                .get('/items/owned')
+                .query(query)
+                .set('Authorization', accessToken);
+
+            expect(response.status).toEqual(400);
+        });
+
+        it('type이 누락되면 예외가 발생한다.', async () => {
+            const { accessToken } = await login(app);
+
+            const query = {
+                grade: 'NORMAL',
+            };
+
+            const response = await request(app.getHttpServer())
+                .get('/items/owned')
+                .query(query)
+                .set('Authorization', accessToken);
+
+            expect(response.status).toEqual(400);
+        });
+
+        it('grade가 누락되면 예외가 발생한다.', async () => {
+            const { accessToken } = await login(app);
+
+            const query = {
+                type: 'AURA',
+            };
+
+            const response = await request(app.getHttpServer())
+                .get('/items/owned')
+                .query(query)
+                .set('Authorization', accessToken);
+
+            expect(response.status).toEqual(400);
+        });
+    });
+});

--- a/test/e2e/item.e2e-spec.ts
+++ b/test/e2e/item.e2e-spec.ts
@@ -1,0 +1,80 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from 'src/app.module';
+import { PrismaService } from 'src/infrastructure/prisma/prisma.service';
+import { login } from 'test/helper/login';
+import { generateItem, generateOwnedItem } from 'test/helper/generators';
+import { ResponseResult } from 'test/helper/types';
+import { ItemGradeEnum, ItemTypeEnum } from 'src/domain/types/item.types';
+import { GetOwnedItemListResponse } from 'src/presentation/dto';
+
+describe('ItemController (e2e)', () => {
+    let app: INestApplication;
+    let db: PrismaService;
+
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        db = moduleFixture.get<PrismaService>(PrismaService);
+        await app.init();
+    });
+
+    afterEach(async () => {
+        await db.userOwnedItem.deleteMany();
+        await db.item.deleteMany();
+        await db.user.deleteMany();
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    describe('GET /items/owned - 소유 아이템 조회', () => {
+        it('소유 아이템을 정상 조회한다', async () => {
+            const { accessToken, userId } = await login(app);
+
+            const items = Array.from({ length: 5 }, (_, i) =>
+                generateItem({
+                    name: `오라${i}`,
+                    description: `설명${i}`,
+                    type: 'AURA',
+                    itemType: ItemTypeEnum.AURA,
+                    key: `aura_key_${i}`,
+                    grade: ItemGradeEnum.NORMAL,
+                }),
+            );
+            const userOwneds = items.map((item) =>
+                generateOwnedItem(userId, item.id),
+            );
+
+            await db.item.createMany({ data: items });
+            await db.userOwnedItem.createMany({ data: userOwneds });
+
+            const query = {
+                type: 'AURA',
+                grade: 'NORMAL',
+            };
+
+            const response = (await request(app.getHttpServer())
+                .get('/items/owned')
+                .query(query)
+                .set(
+                    'Authorization',
+                    accessToken,
+                )) as ResponseResult<GetOwnedItemListResponse>;
+
+            const { status, body } = response;
+
+            expect(status).toBe(200);
+            expect(body.items.length).toBe(5);
+            expect(body.items.every((item) => item.type === 'AURA')).toBe(true);
+            expect(body.items.every((item) => item.grade === 'NORMAL')).toBe(
+                true,
+            );
+        });
+    });
+});

--- a/test/e2e/item.e2e-spec.ts
+++ b/test/e2e/item.e2e-spec.ts
@@ -6,7 +6,12 @@ import { PrismaService } from 'src/infrastructure/prisma/prisma.service';
 import { login } from 'test/helper/login';
 import { generateItem, generateOwnedItem } from 'test/helper/generators';
 import { ResponseResult } from 'test/helper/types';
-import { ItemGradeEnum, ItemTypeEnum } from 'src/domain/types/item.types';
+import {
+    convertNumberToItemGrade,
+    convertNumberToItemType,
+    ItemGradeEnum,
+    ItemTypeEnum,
+} from 'src/domain/types/item.types';
 import { GetOwnedItemListResponse } from 'src/presentation/dto';
 
 describe('ItemController (e2e)', () => {
@@ -71,10 +76,19 @@ describe('ItemController (e2e)', () => {
 
             expect(status).toBe(200);
             expect(body.items.length).toBe(5);
-            expect(body.items.every((item) => item.type === 'AURA')).toBe(true);
-            expect(body.items.every((item) => item.grade === 'NORMAL')).toBe(
-                true,
-            );
+            body.items.forEach((item, i) => {
+                const expected = items[i];
+
+                expect(item).toMatchObject({
+                    id: expected.id,
+                    name: expected.name,
+                    description: expected.description,
+                    type: convertNumberToItemType(expected.itemType),
+                    key: expected.key,
+                    grade: convertNumberToItemGrade(expected.grade),
+                });
+                expect(item.image).toMatch(/^https?:\/\//);
+            });
         });
     });
 });

--- a/test/e2e/product-validation.e2e-spec.ts
+++ b/test/e2e/product-validation.e2e-spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from '../../src/app.module';
-import { ProductType, ProductOrder } from 'src/presentation/dto/shared';
+import { ProductOrder } from 'src/presentation/dto/shared';
 import { login } from 'test/helper/login';
 
 describe('Products Input Validation (e2e)', () => {
@@ -43,7 +43,7 @@ describe('Products Input Validation (e2e)', () => {
             const { accessToken } = await login(app);
 
             const query = {
-                category: ProductType.AURA,
+                category: 'AURA',
                 order: 'old',
                 limit: 20,
                 page: 1,
@@ -60,7 +60,7 @@ describe('Products Input Validation (e2e)', () => {
             const { accessToken } = await login(app);
 
             const query = {
-                category: ProductType.AURA,
+                category: 'AURA',
                 order: ProductOrder.LATEST,
                 limit: 20,
                 page: 0,
@@ -77,7 +77,7 @@ describe('Products Input Validation (e2e)', () => {
             const { accessToken } = await login(app);
 
             const query = {
-                category: ProductType.AURA,
+                category: 'AURA',
                 order: ProductOrder.LATEST,
                 limit: 0,
                 page: 1,
@@ -94,7 +94,7 @@ describe('Products Input Validation (e2e)', () => {
             const { accessToken } = await login(app);
 
             const query = {
-                category: ProductType.AURA,
+                category: 'AURA',
                 order: ProductOrder.LATEST,
                 limit: 31,
                 page: 1,

--- a/test/e2e/product.e2e-spec.ts
+++ b/test/e2e/product.e2e-spec.ts
@@ -7,7 +7,7 @@ import { login } from 'test/helper/login';
 import { ResponseResult } from 'test/helper/types';
 import { generateItem, generateProduct } from 'test/helper/generators';
 import { GetProductListRequest } from 'src/presentation/dto/product/request/get-product-list.request';
-import { ProductType, ProductOrder } from 'src/presentation/dto/shared';
+import { ProductOrder } from 'src/presentation/dto/shared';
 import { GetProductListResponse } from 'src/presentation/dto/product/response/get-product-list.response';
 import {
     convertNumberToGrade,
@@ -43,7 +43,7 @@ describe('ProductController (e2e)', () => {
             generateItem({
                 name: `오라${i}`,
                 description: `오라 설명${i}`,
-                type: ProductType.AURA,
+                type: 'AURA',
                 key: `aura${i}`,
                 grade: ItemGradeEnum.NORMAL,
                 createdAt: new Date(Date.now() + i),
@@ -65,7 +65,7 @@ describe('ProductController (e2e)', () => {
             const { accessToken } = await login(app);
 
             const query = {
-                type: ProductType.AURA,
+                type: 'AURA',
                 order: ProductOrder.CHEAPEST,
                 limit: 7,
             };
@@ -123,7 +123,7 @@ describe('ProductController (e2e)', () => {
                 .sort((a, b) => (a.price > b.price ? 1 : -1));
 
             const query: GetProductListRequest = {
-                type: ProductType.AURA,
+                type: 'AURA',
                 order: ProductOrder.CHEAPEST,
                 limit: 20,
                 page: 1,
@@ -160,7 +160,7 @@ describe('ProductController (e2e)', () => {
                 .sort((a, b) => (a.price < b.price ? 1 : -1));
 
             const query: GetProductListRequest = {
-                type: ProductType.AURA,
+                type: 'AURA',
                 order: ProductOrder.PRICIEST,
                 limit: 20,
                 page: 1,
@@ -202,7 +202,7 @@ describe('ProductController (e2e)', () => {
                 });
 
             const query: GetProductListRequest = {
-                type: ProductType.AURA,
+                type: 'AURA',
                 order: ProductOrder.LATEST,
                 limit: 20,
                 page: 1,

--- a/test/e2e/product.e2e-spec.ts
+++ b/test/e2e/product.e2e-spec.ts
@@ -10,7 +10,7 @@ import { GetProductListRequest } from 'src/presentation/dto/product/request/get-
 import { ProductOrder } from 'src/presentation/dto/shared';
 import { GetProductListResponse } from 'src/presentation/dto/product/response/get-product-list.response';
 import {
-    convertNumberToGrade,
+    convertNumberToItemGrade,
     ItemGradeEnum,
 } from 'src/domain/types/item.types';
 
@@ -117,7 +117,7 @@ describe('ProductController (e2e)', () => {
                     description: auras[i].description,
                     type: auras[i].type,
                     key: auras[i].key,
-                    grade: convertNumberToGrade(auras[i].grade),
+                    grade: convertNumberToItemGrade(auras[i].grade),
                     purchasedStatus: 'NONE',
                 }))
                 .sort((a, b) => (a.price > b.price ? 1 : -1));
@@ -154,7 +154,7 @@ describe('ProductController (e2e)', () => {
                     description: auras[i].description,
                     type: auras[i].type,
                     key: auras[i].key,
-                    grade: convertNumberToGrade(auras[i].grade),
+                    grade: convertNumberToItemGrade(auras[i].grade),
                     purchasedStatus: 'NONE',
                 }))
                 .sort((a, b) => (a.price < b.price ? 1 : -1));
@@ -190,7 +190,7 @@ describe('ProductController (e2e)', () => {
                     description: auras[i].description,
                     type: auras[i].type,
                     key: auras[i].key,
-                    grade: convertNumberToGrade(auras[i].grade),
+                    grade: convertNumberToItemGrade(auras[i].grade),
                     createdAt: product.createdAt,
                     purchasedStatus: 'NONE',
                 }))

--- a/test/e2e/purchase.e2e-spec.ts
+++ b/test/e2e/purchase.e2e-spec.ts
@@ -8,8 +8,7 @@ import {
     generateProduct,
     generatePurchase,
 } from 'test/helper/generators';
-import { ProductType } from 'src/presentation/dto/shared';
-import { ItemGradeEnum } from 'src/domain/types/item.types';
+import { ItemGradeEnum, ItemTypeEnum } from 'src/domain/types/item.types';
 import { login } from 'test/helper/login';
 import { PurchaseRequest } from 'src/presentation/dto/purchases/request/puchase.request';
 
@@ -46,7 +45,8 @@ describe('PurchaseController (e2e)', () => {
             generateItem({
                 name: `오라${i}`,
                 description: `오라 설명${i}`,
-                type: ProductType.AURA,
+                type: '',
+                itemType: ItemTypeEnum.AURA,
                 key: `aura${i}`,
                 grade: ItemGradeEnum.NORMAL,
                 createdAt: new Date(Date.now() + i),

--- a/test/helper/generators.ts
+++ b/test/helper/generators.ts
@@ -134,6 +134,7 @@ export const generateItem = (partial?: Partial<ItemEntity>) => {
         partial?.itemType || ItemTypeEnum.AURA,
         partial?.key || 'aura-1',
         partial?.grade || ItemGradeEnum.NORMAL,
+        partial?.image || 'https://image.com',
         partial?.createdAt || new Date(),
     );
 };

--- a/test/helper/generators.ts
+++ b/test/helper/generators.ts
@@ -13,7 +13,8 @@ import {
     LiveNormalIsland,
 } from 'src/domain/types/game.types';
 import { IslandTypeEnum } from 'src/domain/types/island.types';
-import { ItemGradeEnum } from 'src/domain/types/item.types';
+import { ItemGradeEnum, ItemTypeEnum } from 'src/domain/types/item.types';
+import { ProductTypeEnum } from 'src/domain/types/product.types';
 import { PurchaseStatusEnum } from 'src/domain/types/purchase.types';
 import { Provider } from 'src/shared/types';
 import { v4 } from 'uuid';
@@ -117,6 +118,7 @@ export const generateProduct = (
         partial?.description || '멋진 오라 설명',
         partial?.price || 1000,
         partial?.coverImage || 'https://image.com',
+        partial?.productType || ProductTypeEnum.AURA,
         partial?.createdAt || new Date(),
         partial?.updatedAt || new Date(),
     );
@@ -128,6 +130,7 @@ export const generateItem = (partial?: Partial<ItemEntity>) => {
         partial?.name || '오라',
         partial?.description || '멋진 오라',
         partial?.type || 'aura',
+        partial?.itemType || ItemTypeEnum.AURA,
         partial?.key || 'aura-1',
         partial?.grade || ItemGradeEnum.NORMAL,
         partial?.createdAt || new Date(),

--- a/test/helper/generators.ts
+++ b/test/helper/generators.ts
@@ -6,6 +6,7 @@ import { ItemEntity } from 'src/domain/entities/item/item.entity';
 import { ProducEntity } from 'src/domain/entities/product/product.entity';
 import { PurchaseEntity } from 'src/domain/entities/purchase/purchase.entity';
 import { TagEntity } from 'src/domain/entities/tag/tag.entity';
+import { UserOwnedItemEntity } from 'src/domain/entities/user-owned-items/user-owned-item.entity';
 import { UserEntity } from 'src/domain/entities/user/user.entity';
 import { Player } from 'src/domain/models/game/player';
 import {
@@ -202,4 +203,12 @@ export const generateNormalIslandModel = (
         tags: partial?.tags || ['tag1', 'tag2'],
         ownerId: partial?.ownerId || v4(),
     };
+};
+
+export const generateOwnedItem = (
+    userId: string,
+    itemId: string,
+    aquiredAt = new Date(),
+): UserOwnedItemEntity => {
+    return new UserOwnedItemEntity(v4(), userId, itemId, aquiredAt);
 };

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mmorntype",
-    "version": "1.0.72",
+    "version": "1.0.74",
     "description": "mmorn dto type",
     "typings": "./dist/types/index.d.ts",
     "files": [


### PR DESCRIPTION
## Summary

- 상품, 아이템 테이블에 컬럼 추가.
- 소유 중인 아이템 조회 기능 구현.
- 다음 구현에 사용할 장착 테이블 추가.

## 주요 변경 사항

### 1. `product`, `item` 테이블에 컬럼 추가

- 추가된 컬럼
  - `item` - `item_type`, `image`
  - `product` - `product_type`
  - 각 테이블의 기존 `type` 컬럼은 호환성을 위해 서비스 환경에 배포 후에 제거 예정.

### 2. 소유 중인 아이템 조회 기능 구현

- `type`, `garde` 별로 소유 중인 아이템을 조회하는 기능
  - `GET /items/owned?type={}$grade={}`

### 3. 아이템 장착 내용을 저장할 `equipped_item` 테이블 생성

## 테스트

| 테스트 항목 | 설명 | 종류 |
| ----------- | ---- | ---- |
| 소유 중인 아이템 조회 정상 동작     | | e2e |
| 소유 중인 아이템 조회 입력 값 검증 | | e2e |
