### PR TITLE
island의 mapId 및 실시간 섬의 mapKey 필수 값으로 변경

### DIFF
--- a/prisma/migrations/20250621070338_set_not_null_map_id_to_island/migration.sql
+++ b/prisma/migrations/20250621070338_set_not_null_map_id_to_island/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - Made the column `mapId` on table `island` required. This step will fail if there are existing NULL values in that column.
+
+*/
+
+-- Set mapId to not null
+UPDATE "island" SET "mapId" = (SELECT "id" FROM "map" LIMIT 1);
+
+-- AlterTable
+ALTER TABLE "island" ALTER COLUMN "mapId" SET NOT NULL;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,7 +92,7 @@ model FriendRequest {
 model Island {
   id          String    @id @db.Uuid
   ownerId     String?   @db.Uuid
-  mapId       String?   @db.Uuid
+  mapId       String   @db.Uuid
   name        String?   @db.VarChar(50)
   description String?   @db.VarChar(200)
   coverImage  String?   @map("cover_image")

--- a/src/domain/entities/islands/island.entity.ts
+++ b/src/domain/entities/islands/island.entity.ts
@@ -7,12 +7,13 @@ export interface NormalIslandPrototype {
     readonly description: string;
     readonly coverImage: string;
     readonly ownerId: string;
-    readonly mapKey?: string;
+    readonly mapKey: string;
     readonly deletedAt?: Date;
 }
 
 export interface IslandPrototype {
     readonly maxMembers: number;
+    readonly mapId: string;
     readonly tag?: string;
     readonly type: IslandTypeEnum;
     readonly name?: string;
@@ -20,7 +21,6 @@ export interface IslandPrototype {
     readonly coverImage?: string;
     readonly deletedAt?: Date;
     readonly ownerId?: string;
-    readonly mapId?: string;
 }
 
 export class IslandEntity {
@@ -30,7 +30,7 @@ export class IslandEntity {
         readonly type: IslandTypeEnum,
         readonly createdAt: Date,
         readonly updatedAt: Date,
-        readonly mapId?: string,
+        readonly mapId: string,
         readonly ownerId?: string,
         readonly tag?: string,
         readonly name?: string,

--- a/src/domain/services/game/game-island.service.ts
+++ b/src/domain/services/game/game-island.service.ts
@@ -7,6 +7,7 @@ import { DomainException } from 'src/domain/exceptions/exceptions';
 import { Player } from 'src/domain/models/game/player';
 import {
     JoinedIslandInfo,
+    LiveDesertedIsland,
     LiveIsland,
     SocketClientId,
 } from 'src/domain/types/game.types';
@@ -70,7 +71,7 @@ export class GameIslandService {
             mapId: map.id,
         });
 
-        return this.createLiveIsland(island.id);
+        return this.createLiveIsland(island.id, map.key);
     }
 
     getIsland(islandId: string) {
@@ -176,16 +177,17 @@ export class GameIslandService {
         });
     }
 
-    async createLiveIsland(islandId: string) {
-        const island = {
+    async createLiveIsland(islandId: string, mapKey: string) {
+        const liveIsland: LiveDesertedIsland = {
             id: islandId,
             max: DESERTED_MAX_MEMBERS,
             players: new Set<SocketClientId>(),
             type: IslandTypeEnum.DESERTED,
+            mapKey,
         };
-        await this.desertedIslandStorageWriter.create(island);
+        await this.desertedIslandStorageWriter.create(liveIsland);
 
-        return island;
+        return liveIsland;
     }
 
     async handleLeave(player: Player) {

--- a/src/domain/types/game.types.ts
+++ b/src/domain/types/game.types.ts
@@ -8,7 +8,7 @@ export interface LiveIsland {
     players: Set<string>;
     type: IslandTypeEnum;
     max: number;
-    mapKey?: string;
+    mapKey: string;
 }
 
 export type LiveDesertedIsland = LiveIsland;

--- a/src/infrastructure/redis/islands/deserted-island-redis-storage.ts
+++ b/src/infrastructure/redis/islands/deserted-island-redis-storage.ts
@@ -36,6 +36,7 @@ export class DesertedIslandRedisStorage implements DesertedIslandStorage {
             max: Number(islandInfo.max),
             type: Number(islandInfo.type),
             players: new Set(players),
+            mapKey: islandInfo.mapKey,
         };
     }
 

--- a/src/infrastructure/redis/islands/normal-island-redis-storage.ts
+++ b/src/infrastructure/redis/islands/normal-island-redis-storage.ts
@@ -53,6 +53,7 @@ export class NormalIslandRedisStorage implements NormalIslandStorage {
             tags,
             players: new Set(players),
             ownerId: islandInfo.ownerId,
+            mapKey: islandInfo.mapKey,
         };
     }
 

--- a/src/presentation/dto/game/request/create-island.request.ts
+++ b/src/presentation/dto/game/request/create-island.request.ts
@@ -10,7 +10,6 @@ import {
     IsArray,
     ArrayMaxSize,
     ArrayMinSize,
-    IsOptional,
 } from 'class-validator';
 
 export class CreateIslandRequest {
@@ -47,8 +46,7 @@ export class CreateIslandRequest {
     readonly tags: string[];
 
     @ApiProperty({ example: 'island' })
-    @IsOptional()
     @Length(1, 50)
     @IsString()
-    readonly mapKey?: string;
+    readonly mapKey: string;
 }

--- a/test/e2e/island-gateway.e2e-spec.ts
+++ b/test/e2e/island-gateway.e2e-spec.ts
@@ -160,6 +160,7 @@ describe('IslandGateway (e2e)', () => {
                 max: 3,
                 players: new Set<string>(),
                 type: IslandTypeEnum.DESERTED,
+                mapKey: map.key,
             };
             await desertedIslandStorage.createIsland(island);
             await db.island.create({

--- a/test/unit/services/game-island-create.service.unit-spec.ts
+++ b/test/unit/services/game-island-create.service.unit-spec.ts
@@ -50,9 +50,9 @@ describe('GameIslandService', () => {
         await redis.flushall();
         await db.islandTag.deleteMany();
         await db.playerSpawnPoint.deleteMany();
+        await db.island.deleteMany();
         await db.map.deleteMany();
         await db.tag.deleteMany();
-        await db.island.deleteMany();
         await db.user.deleteMany();
     });
 

--- a/test/unit/services/game-island.service.unit-spec.ts
+++ b/test/unit/services/game-island.service.unit-spec.ts
@@ -71,8 +71,8 @@ describe('GameIslandService', () => {
         await redis.flushall();
         await db.islandJoin.deleteMany();
         await db.playerSpawnPoint.deleteMany();
-        await db.map.deleteMany();
         await db.island.deleteMany();
+        await db.map.deleteMany();
         await db.user.deleteMany();
     });
 


### PR DESCRIPTION
## Summary

- 하위 호환을 위해 옵셔널로 추가했던 map 관련 값들 필수 값으로 변경.

## 주요 변경 사항

### 1. 하위 호환을 위해 옵셔널로 추가했던 map 관련 값들 required로 변경.
- `island` 테이블, `LiveIsland`에서 map 관련 값 필수 값으로 변경

## 테스트
| 테스트 항목 | 설명 | 종류 |
| ----------- | ---- | --- |
| 섬 생성 시 입력 값 검증 테스트  | mapKey를 포함한 모든 속성 입력 값 검증 케이스 8건 | e2e |